### PR TITLE
Fix "Suggest an edit" button on pages.

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,8 +6,8 @@ src = "src"
 title = "Rust Project Goals"
 
 [output.html]
-git-repository-url = "https://github.com/nikomatsakis/rust-project-goals"
-edit-url-template = "https://github.com/nikomatsakis/rust-project-goals/edit/main/{path}"
+git-repository-url = "https://github.com/rust-lang/rust-project-goals"
+edit-url-template = "https://github.com/rust-lang/rust-project-goals/edit/main/{path}"
 
 [output.html.fold]
 enable = true

--- a/book.toml
+++ b/book.toml
@@ -7,7 +7,7 @@ title = "Rust Project Goals"
 
 [output.html]
 git-repository-url = "https://github.com/nikomatsakis/rust-project-goals"
-edit-url-template = "https://github.com/nikomatsakis/rust-project-goals/edit/<branch>/{path}"
+edit-url-template = "https://github.com/nikomatsakis/rust-project-goals/edit/main/{path}"
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
Currently they have the literal "<branch>" string in the URL, which does not work. I confirmed that the generated URL for `introduction.html` now points [a working URL](https://github.com/nikomatsakis/rust-project-goals/edit/main/src/introduction.md).

It appears the mdBook does not currently have support for substituting anything other than "{page}": 
https://github.com/rust-lang/mdBook/blob/master/src/renderer/html_handlebars/hbs_renderer.rs#L52