### PR TITLE
Add Cargo to 'Faster iterative builds'

### DIFF
--- a/src/2024h2/faster-iterative-builds.md
+++ b/src/2024h2/faster-iterative-builds.md
@@ -7,7 +7,7 @@
 | Status | WIP |
 
 [Lang]: https://www.rust-lang.org/governance/teams/lang
-[Compiler]: https://www.rust-lang.org/governance/teams/library#team-compiler
+[Compiler]: https://www.rust-lang.org/governance/teams/compiler
 [Cargo]: https://www.rust-lang.org/governance/teams/dev-tools#team-cargo
 
 ## Motivation

--- a/src/2024h2/faster-iterative-builds.md
+++ b/src/2024h2/faster-iterative-builds.md
@@ -3,11 +3,12 @@
 | Metadata | |
 | --- | --- |
 | Owner(s) | [jkelleyrtp][] |
- Teams    | [Lang], [Compiler]            |
+| Teams    | [Lang], [Compiler], [Cargo]            |
 | Status | WIP |
 
 [Lang]: https://www.rust-lang.org/governance/teams/lang
 [Compiler]: https://www.rust-lang.org/governance/teams/library#team-compiler
+[Cargo]: https://www.rust-lang.org/governance/teams/dev-tools#team-cargo
 
 ## Motivation
 


### PR DESCRIPTION
The global dependency cache is purely a Cargo feature

CC @jkelleyrtp 