### PR TITLE
Fix github issue linkifiers

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -17,8 +17,8 @@ command = "cargo run -p mdbook-goals --"
 
 [preprocessor.goals.linkifiers]
 "RFC #([0-9]+)" = "https://github.com/rust-lang/rfcs/pull/$1"
-"([a-zA-Z0-9-]+)/([a-zA-Z0-9-]+)#([0-9]+)" = "https://github.com/$1/$2/issue/$3"
-"#([0-9]+)" = "https://github.com/rust-lang/rust/issue/$1"
+"([a-zA-Z0-9-]+)/([a-zA-Z0-9-]+)#([0-9]+)" = "https://github.com/$1/$2/issues/$3"
+"#([0-9]+)" = "https://github.com/rust-lang/rust/issues/$1"
 
 [preprocessor.goals.users]
 "@Nadrieril" = "@Nadrieril"


### PR DESCRIPTION
The github issue linkifiers give links such as
[`https://github.com/rust-lang/cargo/issue/12207`](https://github.com/rust-lang/cargo/issue/12207) (on https://rust-lang.github.io/rust-project-goals/2024h2/cargo-script.html) which 404s and should instead be
[`https://github.com/rust-lang/cargo/issues/12207`](https://github.com/rust-lang/cargo/issues/12207)

Seems to be from https://github.com/rust-lang/rust-project-goals/commit/8b2c6357f48e91ef6a7f8f21a91e7a0b749d29ea#diff-5ba8f0fb0be6c41cd7ab7b18176816db5e5172549b614d6a219c4905c918e218R27-R28

(the github web editor appended a new line to the file which hopefully isn't a problem...)