### PR TITLE
List Alice as responsible for real-world usage of asm-goto

### DIFF
--- a/src/2024h2/rfl_stable.md
+++ b/src/2024h2/rfl_stable.md
@@ -154,7 +154,7 @@ Here is a detailed list of the work to be done and who is expected to do it. Thi
 | ↳ Stabilization decision           | ![Team][] [lang]             |                           |
 | `asm_goto`                         | @nbdd0121                    |                           |
 | ↳ ~~implementation~~               |                              | ![Complete][]             |
-| ↳ Real-world usage in Linux kernel |                              |                           |
+| ↳ Real-world usage in Linux kernel | @Darksonn                    |                           |
 | ↳ Extend to cover full RFC         |                              |                           |
 | ↳ Author stabilization report      |                              |                           |
 | ↳ Stabilization decision           | ![Team][] [lang]             |                           |


### PR DESCRIPTION
I'm the one working on real-world usage of asm-goto in the Linux kernel, so add that to the table.