### PR TITLE
add derive to mdbook-goals

### DIFF
--- a/crates/mdbook-goals/Cargo.toml
+++ b/crates/mdbook-goals/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.94"
-clap = "4.5.23"
+clap = { version = "4.5.23", features = ["derive"] }
 mdbook = "0.4.43"
 regex = "1.11.1"
 rust-project-goals = { version = "0.1.0", path = "../rust-project-goals" }


### PR DESCRIPTION
cargo check --all didn't detect this problem
because the feature wound up inherited from
elsewhere.