### PR TITLE
adopt INVITED goal terminology

### DIFF
--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -117,7 +117,7 @@ impl GoalDocument {
         let link_path = Arc::new(link_path.to_path_buf());
 
         let plan_items = match metadata.status {
-            Status::Flagship | Status::Accepted | Status::Proposed | Status::Orphaned => {
+            Status::Flagship | Status::Accepted | Status::Proposed => {
                 extract_plan_items(&sections)?
             }
             Status::NotAccepted => vec![],
@@ -153,7 +153,7 @@ impl GoalDocument {
     /// True if this goal is a candidate (may yet be accepted)
     pub fn is_not_not_accepted(&self) -> bool {
         match self.metadata.status {
-            Status::Flagship | Status::Accepted | Status::Proposed | Status::Orphaned => true,
+            Status::Flagship | Status::Accepted | Status::Proposed => true,
             Status::NotAccepted => false,
         }
     }
@@ -298,7 +298,6 @@ pub enum Status {
     Flagship,
     Accepted,
     Proposed,
-    Orphaned,
     NotAccepted,
 }
 
@@ -310,7 +309,6 @@ impl TryFrom<&str> for Status {
             ("Flagship", Status::Flagship),
             ("Accepted", Status::Accepted),
             ("Proposed", Status::Proposed),
-            ("Orphaned", Status::Orphaned),
             ("Not accepted", Status::NotAccepted),
         ];
 

--- a/src/2024h2/accepted.md
+++ b/src/2024h2/accepted.md
@@ -4,4 +4,4 @@ This page lists the project goals accepted for 2024h2, with the exception of [fl
 
 Some goals here do not yet have an owner (look for the ![Help wanted][] badge). Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these orphaned goals, reach out to the mentor listed in the goal to discuss.
 
-<!-- GOALS 'Accepted,Orphaned' -->
+<!-- GOALS 'Accepted' -->

--- a/src/2024h2/goals.md
+++ b/src/2024h2/goals.md
@@ -14,4 +14,4 @@ These are the other accepted goals.
 
 **Orphaned goals.** Some goals here are marked with the ![Help wanted][] badge for their owner. These goals are called "orphaned goals". Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these orphaned goals, reach out to the mentor listed in the goal to discuss.
 
-<!-- GOALS 'Accepted,Orphaned' -->
+<!-- GOALS 'Accepted' -->

--- a/src/2024h2/user-wide-cache.md
+++ b/src/2024h2/user-wide-cache.md
@@ -1,10 +1,10 @@
 # User-wide build cache
 
 | Metadata       |                                    |
-| ---            | ---                                |
+|----------------|------------------------------------|
 | Owner(s)       | ![Help wanted][]                   |
 | Teams          | [cargo]                            |
-| Status         | Orphaned                           |
+| Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#124] |
 
 
@@ -115,7 +115,7 @@ idempotence (and verify the opt-in mentioned earlier).
 *This section defines the specific work items that are planned and who is expected to do them. It should also include what will be needed from Rust teams. The table below shows some common sets of asks and work, but feel free to adjust it as needed. Every row in the table should either correspond to something done by a contributor or something asked of a team. For items done by a contributor, list the contributor, or ![Heap wanted][] if you don't yet know who will do it. For things asked of teams, list ![Team][] and the name of the team. The things typically asked of teams are defined in the [Definitions](#definitions) section below.*
 
 | Subgoal                  | Owner(s) or team(s) | Notes |
-| ------------------------ | ------------------- | ----- |
+|--------------------------|---------------------|-------|
 | User-wide caching        |                     |       |
 | ↳ Implementation         | Goal owner          |       |
 | ↳ Standard reviews       | ![Team][] [cargo]   |       |

--- a/src/2025h1/README.md
+++ b/src/2025h1/README.md
@@ -51,7 +51,7 @@ The flagship goals proposed for this roadmap are as follows:
 
 The full slate of project goals are as follows. These goals all have identified owners who will drive the work forward as well as a viable work plan. The goals include asks from the listed Rust teams, which are cataloged in the [reference-level explanation](#reference-level-explanation) section below.
 
-Some goals here do not yet have an owner (look for the ![Help wanted][] badge). Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these orphaned goals, reach out to the mentor listed in the goal to discuss.
+**Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as an owner. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
 <!-- GOALS 'Proposed' -->
 

--- a/src/2025h1/goals.md
+++ b/src/2025h1/goals.md
@@ -16,6 +16,6 @@ Flagship goals represent the goals expected to have the broadest overall impact.
 
 These are the other proposed goals. 
 
-**Orphaned goals.** Some goals here are marked with the ![Help wanted][] badge for their owner. These goals are called "orphaned goals". Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these orphaned goals, reach out to the mentor listed in the goal to discuss.
+**Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as an owner. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- GOALS 'Accepted,Proposed,Orphaned' -->
+<!-- GOALS 'Accepted,Proposed' -->

--- a/src/admin/mdbook_plugin.md
+++ b/src/admin/mdbook_plugin.md
@@ -33,4 +33,4 @@ The placeholder <code>&lt;-- #GOALS --&gt;</code> will be replaced with the tota
 
 ### Goal listing
 
-The placeholder <code>&lt;-- GOALS '$Status' --&gt;</code> will insert a goal table listing goals of the given status `$Status`, e.g., <code>&lt;-- GOALS 'Flagship' --&gt;</code>. You can also list multiple status items, e.g., <code>&lt;-- GOALS 'Accepted,Orphaned' --&gt;</code>
+The placeholder <code>&lt;-- GOALS '$Status' --&gt;</code> will insert a goal table listing goals of the given status `$Status`, e.g., <code>&lt;-- GOALS 'Flagship' --&gt;</code>. You can also list multiple status items, e.g., <code>&lt;-- GOALS 'Accepted,Proposed' --&gt;</code>

--- a/src/admin/samples/goals.md
+++ b/src/admin/samples/goals.md
@@ -20,6 +20,6 @@ Flagship goals represent the goals expected to have the broadest overall impact.
 
 These are the other proposed goals. 
 
-**Orphaned goals.** Some goals here are marked with the ![Help wanted][] badge for their owner. These goals are called "orphaned goals". Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these orphaned goals, reach out to the mentor listed in the goal to discuss.
+**Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as an owner. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- GOALS 'Accepted,Proposed,Orphaned' -->
+<!-- GOALS 'Accepted,Proposed' -->

--- a/src/admin/samples/rfc.md
+++ b/src/admin/samples/rfc.md
@@ -61,9 +61,9 @@ The flagship goals proposed for this roadmap are as follows:
 
 The full slate of project goals are as follows. These goals all have identified owners who will drive the work forward as well as a viable work plan. The goals include asks from the listed Rust teams, which are cataloged in the [reference-level explanation](#reference-level-explanation) section below.
 
-Some goals here do not yet have an owner (look for the ![Help wanted][] badge). Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these orphaned goals, reach out to the mentor listed in the goal to discuss.
+**Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as an owner. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- GOALS 'Accepted,Orphaned' -->
+<!-- GOALS 'Proposed' -->
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation


### PR DESCRIPTION
The term orphaned goal is confusing -- it implies they used to have parents but no longer do.

Invited captures the spirit better. These are goals we WANT people to do.