### PR TITLE
Add "Rendered link" to PR to quick see the rendered changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,2 @@
+[rendered-link]
+trigger-files = ["src/"]


### PR DESCRIPTION
This PR adds "Rendered link" to PR to quick see the rendered changes.

I have configured it to only trigger on files under the `src/` directory.

<details>
<summary>Example</summary>

![image](https://github.com/user-attachments/assets/f0870f8f-f532-4928-ac5d-85b4e0b79a21)

</details>

*Note, despite the `triagebot.toml` being new, triagebot/rustbot is [already activated](https://github.com/rust-lang/team/blob/a70b006508ef56a42cdd7eae1a16753f0289054e/repos/rust-lang/rust-project-goals.toml#L5) for this repo.*