### PR TITLE
add zulip channels

### DIFF
--- a/src/2024h2/ATPIT.md
+++ b/src/2024h2/ATPIT.md
@@ -7,7 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#103] |
-
+| Zulip channel  | N/A                                |
 
 ## Summary
 

--- a/src/2024h2/Contracts-and-invariants.md
+++ b/src/2024h2/Contracts-and-invariants.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status   | Not accepted               |
+| Zulip channel  | N/A                                |
 
 ## Motivation
 

--- a/src/2024h2/Patterns-of-empty-types.md
+++ b/src/2024h2/Patterns-of-empty-types.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#115] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/Polonius.md
+++ b/src/2024h2/Polonius.md
@@ -7,7 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#118] |
+| Zulip channel  | [#t-types/polonius][channel]       |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/186049-t-types.2Fpolonius
 
 ## Summary
 

--- a/src/2024h2/Project-goal-slate.md
+++ b/src/2024h2/Project-goal-slate.md
@@ -7,6 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#102] |
+| Zulip channel  | [#project-goals][channel]               |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/435869-project-goals
 
 
 *Extracted from [RFC 3614](https://github.com/rust-lang/rfcs/blob/master/text/3614-project-goals.md)*

--- a/src/2024h2/Relaxing-the-Orphan-Rule.md
+++ b/src/2024h2/Relaxing-the-Orphan-Rule.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status   | Not accepted        |
+| Zulip channel  | N/A                                |
 
 ## Summary
 

--- a/src/2024h2/Rust-2024-Edition.md
+++ b/src/2024h2/Rust-2024-Edition.md
@@ -7,6 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Flagship                           |
 | Tracking issue | [rust-lang/rust-project-goals#117] |
+| Zulip channel  | [#edition][channel]                |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/268952-edition
 
 
 ## Summary

--- a/src/2024h2/Rust-for-SciComp.md
+++ b/src/2024h2/Rust-for-SciComp.md
@@ -8,6 +8,7 @@
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#109] |
 | Other tracking issues | [rust-lang/rust#124509], [rust-lang/rust#124509] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/Seamless-C-Support.md
+++ b/src/2024h2/Seamless-C-Support.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status | Not accepted |
+| Zulip channel  | N/A                                |
 
 ## Summary
 

--- a/src/2024h2/a-mir-formality.md
+++ b/src/2024h2/a-mir-formality.md
@@ -7,7 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#122] |
+| Zulip channel  | [#t-types/formality][channel]      |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality
 
 ## Summary
 

--- a/src/2024h2/annotate-snippets.md
+++ b/src/2024h2/annotate-snippets.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#123] |
+| Zulip channel    | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/async.md
+++ b/src/2024h2/async.md
@@ -8,7 +8,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Flagship                           |
 | Tracking issue | [rust-lang/rust-project-goals#105] |
+| Zulip channel  | [#wg-async][channel]               |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
 
 ## Summary
 

--- a/src/2024h2/cargo-script.md
+++ b/src/2024h2/cargo-script.md
@@ -2,12 +2,12 @@
 
 | Metadata       |                                    |
 | ---            | ---                                |
-| Point of contact | @epage                             |
+| Point of contact | @epage                           |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#119] |
-
+| Zulip channel  | N/A                                |
 
 ## Summary
 

--- a/src/2024h2/cargo-semver-checks.md
+++ b/src/2024h2/cargo-semver-checks.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#104] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/const-traits.md
+++ b/src/2024h2/const-traits.md
@@ -1,13 +1,15 @@
 # Const traits
 
-| Metadata       |                                    |
-| ---            | ---                                |
-| Point of contact | @fee1-dead                         |
+| Metadata       |                                             |
+| ---            | ---                                         |
+| Point of contact | @fee1-dead                                |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status         | Accepted                           |
-| Tracking issue | [rust-lang/rust-project-goals#106] |
+| Status         | Accepted                                    |
+| Tracking issue | [rust-lang/rust-project-goals#106]          |
+| Zulip channel  | [#t-compiler/project-const-traits][channel] |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/419616-t-compiler.2Fproject-const-traits
 
 ## Summary
 

--- a/src/2024h2/doc_cfg.md
+++ b/src/2024h2/doc_cfg.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#120] |
+| Zulip channel  | N/A                                |
 
 
 @GuillaumeGomez: https://github.com/GuillaumeGomez

--- a/src/2024h2/ergonomic-rc.md
+++ b/src/2024h2/ergonomic-rc.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#107] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/ergonomics-initiative.md
+++ b/src/2024h2/ergonomics-initiative.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status   | Not accepted |
+| Zulip channel  | N/A                                |
 
 ## Motivation
 

--- a/src/2024h2/faster-iterative-builds.md
+++ b/src/2024h2/faster-iterative-builds.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Not accepted                |
+| Zulip channel  | N/A                                |
 
 ## Summary
 

--- a/src/2024h2/merged-doctests.md
+++ b/src/2024h2/merged-doctests.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#111] |
+| Zulip channel  | N/A                                |
 
 
 @GuillaumeGomez: https://github.com/GuillaumeGomez

--- a/src/2024h2/min_generic_const_arguments.md
+++ b/src/2024h2/min_generic_const_arguments.md
@@ -7,7 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#100] |
+| Zulip channel  | [#project-const-generics][channel] |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/260443-project-const-generics/
 
 ## Summary
 

--- a/src/2024h2/next-solver.md
+++ b/src/2024h2/next-solver.md
@@ -1,12 +1,15 @@
 # Next-generation trait solver
 
-| Metadata       |                                    |
-|----------------|------------------------------------|
-| Point of contact | @lcnr                              |
+| Metadata       |                                           |
+|----------------|-------------------------------------------|
+| Point of contact | @lcnr                                   |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status         | Accepted                           |
-| Tracking issue | [rust-lang/rust-project-goals#113] |
+| Status         | Accepted                                  |
+| Tracking issue | [rust-lang/rust-project-goals#113]        |
+| Zulip channel  | [#t-types/trait-system-refactor][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor
 
 
 ## Summary

--- a/src/2024h2/optimize-clippy.md
+++ b/src/2024h2/optimize-clippy.md
@@ -8,6 +8,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#114] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/parallel-front-end.md
+++ b/src/2024h2/parallel-front-end.md
@@ -1,12 +1,15 @@
 # Stabilize parallel front end
 
-| Metadata       |                                    |
-| ---            | ---                                |
-| Point of contact | @SparrowLii                        |
+| Metadata       |                                          |
+| ---            | ---                                      |
+| Point of contact | @SparrowLii                            |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status         | Accepted                           |
-| Tracking issue | [rust-lang/rust-project-goals#121] |
+| Status         | Accepted                                 |
+| Tracking issue | [rust-lang/rust-project-goals#121]       |
+| Zulip channel  | [#t-compiler/wg-parallel-rustc][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fwg-parallel-rustc/
 
 
 ## Summary

--- a/src/2024h2/pubgrub-in-cargo.md
+++ b/src/2024h2/pubgrub-in-cargo.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#110] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/rfl_stable.md
+++ b/src/2024h2/rfl_stable.md
@@ -8,7 +8,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Flagship                           |
 | Tracking issue   | [rust-lang/rust-project-goals#116] |
+| Zulip channel    | [#rust-for-linux][channel]         |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux/
 
 ## Summary
 

--- a/src/2024h2/rustdoc-search.md
+++ b/src/2024h2/rustdoc-search.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#112] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/sandboxed-build-script.md
+++ b/src/2024h2/sandboxed-build-script.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#108] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/std-verification.md
+++ b/src/2024h2/std-verification.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#126] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/user-wide-cache.md
+++ b/src/2024h2/user-wide-cache.md
@@ -7,6 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Invited                            |
 | Tracking issue   | [rust-lang/rust-project-goals#124] |
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2024h2/yank-crates-with-a-reason.md
+++ b/src/2024h2/yank-crates-with-a-reason.md
@@ -7,7 +7,7 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#101] |
-
+| Zulip channel  | N/A                                |
 
 
 ## Summary

--- a/src/2025h1/GPU-Offload.md
+++ b/src/2025h1/GPU-Offload.md
@@ -8,6 +8,9 @@
 | Status                | Proposed                                         |
 | Tracking issue        | [rust-lang/rust-project-goals#109]               |
 | Other tracking issues | [rust-lang/rust#124509], [rust-lang/rust#124509] |
+| Zulip channel         | [#wg-autodiff][channel]                          |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/390790-wg-autodiff
 
 
 ## Summary

--- a/src/2025h1/Polonius.md
+++ b/src/2025h1/Polonius.md
@@ -6,7 +6,9 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Proposed                           |
+| Zulip channel  | [#t-types/polonius][channel]       |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/186049-t-types.2Fpolonius
 
 
 ## Summary

--- a/src/2025h1/all-hands.md
+++ b/src/2025h1/all-hands.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed for flagship            |
+| Zulip channel    | N/A                  |
 
 ## Summary
 

--- a/src/2025h1/annotate-snippets.md
+++ b/src/2025h1/annotate-snippets.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed   |
+| Zulip channel    | N/A        |
 
 
 ## Summary

--- a/src/2025h1/arm-sve-sme.md
+++ b/src/2025h1/arm-sve-sme.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed                    |
+| Zulip channel    | N/A                         |
 
 *Arm's Rust team is @davidtwco, @adamgemmell, @jacobbramley, @JamieCunliffe and @Jamesbarford, as
 well as @mrkajetanp and @harmou01 as graduates on rotation. This goal will be primarily worked on

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -2,10 +2,13 @@
 
 | Metadata |                                     |
 |----------|-------------------------------------|
-| Point of contact | @tmandry                            |
+| Point of contact | @tmandry                    |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed for flagship                           |
+| Status           | Proposed for flagship       |
+| Zulip channel    | [#wg-async][channel]        |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
 
 ## Summary
 

--- a/src/2025h1/build-std.md
+++ b/src/2025h1/build-std.md
@@ -1,11 +1,12 @@
 # build-std
 
-| Metadata |                  |
-|----------|------------------|
-| Point of contact | @davidtwco |
+| Metadata         |                  |
+|------------------|------------------|
+| Point of contact | @davidtwco       |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed         |
+| Status           | Proposed         |
+| Zulip channel    | N/A              |
 
 *Arm's Rust team is @davidtwco, @adamgemmell, @jacobbramley, @JamieCunliffe and @Jamesbarford. This
 goal will be primarily worked on by @adamgemmell, but @davidtwco can always be contacted for

--- a/src/2025h1/cargo-plumbing.md
+++ b/src/2025h1/cargo-plumbing.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed for mentorship |
+| Zulip channel    | N/A                     |
 
 ## Summary
 

--- a/src/2025h1/cargo-semver-checks.md
+++ b/src/2025h1/cargo-semver-checks.md
@@ -1,11 +1,12 @@
 # Continue resolving `cargo-semver-checks` blockers for merging into cargo
 
-| Metadata       |                                    |
-| ---            | ---                                |
+| Metadata         |                                    |
+| ---              | ---                                |
 | Point of contact | @obi1kenobi                        |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status         | Proposed                           |
+| Status           | Proposed                           |
+| Zulip channel    | N/A                                |
 
 
 ## Summary

--- a/src/2025h1/compiletest-directive-rework.md
+++ b/src/2025h1/compiletest-directive-rework.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed                |
+| Zulip channel    | N/A                     |
 
 ## Summary
 

--- a/src/2025h1/eii.md
+++ b/src/2025h1/eii.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed           |
+| Zulip channel    | N/A                |
 
 ## Summary
 

--- a/src/2025h1/ergonomic-rc.md
+++ b/src/2025h1/ergonomic-rc.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed    |
+| Zulip channel    | N/A                |
 
 ## Summary
 

--- a/src/2025h1/field-projections.md
+++ b/src/2025h1/field-projections.md
@@ -1,11 +1,12 @@
 # Field Projections
 
-| Metadata |                            |
-|----------|----------------------------|
+| Metadata         |                            |
+|------------------|----------------------------|
 | Point of contact | @y86-dev                   |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed                   |
+| Status           | Proposed                   |
+| Zulip channel    | N/A                        |
 
 ## Summary
 

--- a/src/2025h1/formality.md
+++ b/src/2025h1/formality.md
@@ -6,6 +6,9 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed      |
+| Zulip channel  | [#t-types/formality][channel]      |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality
 
 ## Summary
 

--- a/src/2025h1/improve-rustc-codegen.md
+++ b/src/2025h1/improve-rustc-codegen.md
@@ -16,6 +16,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed    |
+| Zulip channel    | N/A         |
 
 ## Summary
 

--- a/src/2025h1/libtest-json.md
+++ b/src/2025h1/libtest-json.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed                    |
+| Zulip channel    | N/A                         |
 
 ## Summary
 

--- a/src/2025h1/macro-improvements.md
+++ b/src/2025h1/macro-improvements.md
@@ -1,11 +1,12 @@
 # Declarative (`macro_rules!`) macro improvements
 
-| Metadata |               |
-|----------|---------------|
+| Metadata         |               |
+|------------------|---------------|
 | Point of contact | @joshtriplett |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed      |
+| Status           | Proposed      |
+| Zulip channel    | N/A           |
 
 ## Summary
 

--- a/src/2025h1/metrics-initiative.md
+++ b/src/2025h1/metrics-initiative.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS -->     |
 | Status           | Proposed                 |
+| Zulip channel    | N/A                      |
 
 ## Summary
 

--- a/src/2025h1/min_generic_const_arguments.md
+++ b/src/2025h1/min_generic_const_arguments.md
@@ -7,7 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Proposed                           |
 | Tracking issue | [rust-lang/rust-project-goals#100] |
+| Zulip channel  | [#project-const-generics][channel] |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/260443-project-const-generics/
 
 ## Summary
 

--- a/src/2025h1/next-solver.md
+++ b/src/2025h1/next-solver.md
@@ -7,6 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Proposed                           |
 | Tracking issue | [rust-lang/rust-project-goals#113] |
+| Zulip channel  | [#t-types/trait-system-refactor][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor
 
 
 ## Summary

--- a/src/2025h1/null-enum-discriminant-debug-checks.md
+++ b/src/2025h1/null-enum-discriminant-debug-checks.md
@@ -1,11 +1,12 @@
 # Null and enum-discriminant runtime checks in debug builds
 
-| Metadata |             |
-|----------|-------------|
-| Point of contact | @1c3t3a     |
+| Metadata         |                      |
+|------------------|----------------------|
+| Point of contact | @1c3t3a              |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed    |
+| Status           | Proposed             |
+| Zulip channel    | N/A                  |
 
 ## Summary
 

--- a/src/2025h1/open-namespaces.md
+++ b/src/2025h1/open-namespaces.md
@@ -7,6 +7,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed for mentorship          |
+| Zulip channel    | N/A                              |
 
 ## Summary
 

--- a/src/2025h1/optimize-clippy-linting-2.md
+++ b/src/2025h1/optimize-clippy-linting-2.md
@@ -1,13 +1,14 @@
 # Optimizing Clippy & linting
 (a.k.a The Clippy Performance Project)
 
-| Metadata       |                                    |
-|----------------|------------------------------------|
+| Metadata         |                                    |
+|------------------|------------------------------------|
 | Point of contact | @blyxyas                           |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status         | Proposed                           |
-| Tracking issue | [rust-lang/rust-project-goals#114] |
+| Status           | Proposed                           |
+| Tracking issue   | [rust-lang/rust-project-goals#114] |
+| Zulip channel    | N/A                                |
 
 ## Summary
 

--- a/src/2025h1/parallel-front-end.md
+++ b/src/2025h1/parallel-front-end.md
@@ -7,7 +7,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#121] |
+| Zulip channel  | [#t-compiler/wg-parallel-rustc][channel] |
 
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fwg-parallel-rustc/
 
 ## Summary
 

--- a/src/2025h1/perf-improvements.md
+++ b/src/2025h1/perf-improvements.md
@@ -6,6 +6,9 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed            |
+| Zulip channel    | [#project-goals/2025h1/rustc-perf-improvements][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/478771-project-goals.2F2025h1.2Frustc-perf-improvements
 
 *Arm's Rust team is @davidtwco, @adamgemmell, @jacobbramley, @JamieCunliffe and @Jamesbarford.
 This goal will be primarily worked on by @Jamesbarford, but @davidtwco can always be contacted for

--- a/src/2025h1/pub-priv.md
+++ b/src/2025h1/pub-priv.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed for mentorship |
+| Zulip channel    | N/A                  |
 
 ## Summary
 

--- a/src/2025h1/pubgrub-in-cargo.md
+++ b/src/2025h1/pubgrub-in-cargo.md
@@ -1,11 +1,12 @@
 # Extend pubgrub to match cargo's dependency resolution
 
-| Metadata |          |
-|----------|----------|
-| Point of contact | @eh2406  |
+| Metadata         |                    |
+|------------------|--------------------|
+| Point of contact | @eh2406            |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed |
+| Status           | Proposed           |
+| Zulip channel    | N/A                |
 
 
 ## Summary

--- a/src/2025h1/restrictions.md
+++ b/src/2025h1/restrictions.md
@@ -1,11 +1,12 @@
 # Implement restrictions, prepare for stabilization
 
-| Metadata |          |
-|----------|----------|
-| Point of contact | @jhpratt |
+| Metadata         |                   |
+|------------------|-------------------|
+| Point of contact | @jhpratt          |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed |
+| Status           | Proposed          |
+| Zulip channel    | N/A               |
 
 [rfc]: https://rust-lang.github.io/rfcs/3323-restrictions.html
 [pr]: https://github.com/rust-lang/rust/pull/106074

--- a/src/2025h1/rfl.md
+++ b/src/2025h1/rfl.md
@@ -8,6 +8,9 @@
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed for flagship              |
 | Tracking issue   | [rust-lang/rust-project-goals#116] |
+| Zulip channel    | [#rust-for-linux][channel]               |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux/
 
 ## Summary
 

--- a/src/2025h1/rust-vision-doc.md
+++ b/src/2025h1/rust-vision-doc.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed             |
+| Zulip channel    | N/A                  |
 
 ## Summary
 

--- a/src/2025h1/safe-linking.md
+++ b/src/2025h1/safe-linking.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed           |
+| Zulip channel    | N/A                |
 
 ## Summary
 

--- a/src/2025h1/seamless-rust-cpp.md
+++ b/src/2025h1/seamless-rust-cpp.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed                     |
+| Zulip channel    | N/A                          |
 
 ## Summary
 

--- a/src/2025h1/simd-multiversioning.md
+++ b/src/2025h1/simd-multiversioning.md
@@ -1,11 +1,14 @@
 # Nightly support for ergonomic SIMD multiversioning
 
-| Metadata         |           |
-|------------------|-----------|
-| Point of contact | @veluca93 |
+| Metadata         |                                   |
+|------------------|-----------------------------------|
+| Point of contact | @veluca93                         |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed  |
+| Status           | Proposed                          |
+| Zulip channel    | [#project-portable-simd][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/257879-project-portable-simd/
 
 
 ## Summary

--- a/src/2025h1/spec-fls-integration.md
+++ b/src/2025h1/spec-fls-integration.md
@@ -1,11 +1,14 @@
 # Integration of the FLS into the Rust Project
 
-| Metadata |             |
-|----------|-------------|
-| Point of contact | @joelmarcey |
+| Metadata         |                      |
+|------------------|----------------------|
+| Point of contact | @joelmarcey          |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed    |
+| Status           | Proposed             |
+| Zulip channel    | [#t-spec][channel]   |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/399173-t-spec
 
 ## Summary
 

--- a/src/2025h1/spec-testing.md
+++ b/src/2025h1/spec-testing.md
@@ -1,11 +1,14 @@
 # Rust Specification Testing
 
-| Metadata         |              |
-|------------------|--------------|
-| Point of contact | @chorman0773 |
+| Metadata         |                    |
+|------------------|--------------------|
+| Point of contact | @chorman0773       |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed     |
+| Status           | Proposed           |
+| Zulip channel    | [#t-spec][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/399173-t-spec
 
 ## Summary
 

--- a/src/2025h1/stabilize-project-goal-program.md
+++ b/src/2025h1/stabilize-project-goal-program.md
@@ -1,11 +1,14 @@
 # Run the 2025H1 project goal program
 
-| Metadata         |                      |
-|------------------|----------------------|
-| Point of contact | @nikomatsakis        |
+| Metadata         |                           |
+|------------------|---------------------------|
+| Point of contact | @nikomatsakis             |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed             |
+| Status           | Proposed                  |
+| Zulip channel    | [#project-goals][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/435869-project-goals
 
 ## Summary
 

--- a/src/2025h1/stable-mir.md
+++ b/src/2025h1/stable-mir.md
@@ -1,11 +1,14 @@
 # Publish first version of StableMIR on crates.io
 
-| Metadata |                      |
-|----------|----------------------|
-| Point of contact | @celinval            |
+| Metadata         |                                |
+|------------------|--------------------------------|
+| Point of contact | @celinval                      |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed             |
+| Status           | Proposed                       |
+| Zulip channel    | [#project-stable-mir][channel] |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/320896-project-stable-mir
 
 ## Summary
 

--- a/src/2025h1/std-contracts.md
+++ b/src/2025h1/std-contracts.md
@@ -6,6 +6,7 @@
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed         |
+| Zulip channel    | N/A                |
 
 ## Summary
 

--- a/src/2025h1/unsafe-fields.md
+++ b/src/2025h1/unsafe-fields.md
@@ -1,11 +1,12 @@
 # Unsafe Fields
 
-| Metadata |          |
-|----------|----------|
-| Point of contact | @jswrenn |
+| Metadata         |                      |
+|------------------|----------------------|
+| Point of contact | @jswrenn             |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed |
+| Status           | Proposed             |
+| Zulip channel    | N/A                  |
 
 ## Summary
 

--- a/src/2025h1/verification-and-mirroring.md
+++ b/src/2025h1/verification-and-mirroring.md
@@ -1,11 +1,12 @@
 # Secure quorum-based cryptographic verification and mirroring for crates.io
 
-| Metadata |                         |
-|----------|-------------------------|
+| Metadata         |                         |
+|------------------|-------------------------|
 | Point of contact | @walterhpearce          |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status   | Proposed                |
+| Status           | Proposed                |
+| Zulip channel    | N/A                     |
 
 ## Summary
 

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -11,12 +11,13 @@
 > The **status** should be either **Proposed** (if you have owners)
 > or **Proposed, Invited** (if you do not yet).
 
-| Metadata         |                                                    |
-|------------------|----------------------------------------------------|
-| Point of contact | *must be a single Github username like @ghost*     |
+| Metadata         |                                                                                  |
+|------------------|----------------------------------------------------------------------------------|
+| Point of contact | *must be a single Github username like @ghost*                                   |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed                                           |
+| Status           | Proposed                                                                         |
+| Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
 
 ## Summary
 


### PR DESCRIPTION
I've added a stream where there was an obvious candidate, but avoided adding any generic `#t-compiler`/`#t-types`/`#t-cargo`-like streams to any goals.

cc @nikomatsakis 
cc https://rust-lang.zulipchat.com/#narrow/channel/478266-project-goals.2Fmeta/topic/streams.20for.20goals

[Rendered](https://github.com/davidtwco/rust-project-goals/blob/zulip-channel/src/2024h2/ATPIT.md)