### PR TITLE
Revisit the null-enum-discriminant-debug-checks goal

### DIFF
--- a/src/2025h1/null-enum-discriminant-debug-checks.md
+++ b/src/2025h1/null-enum-discriminant-debug-checks.md
@@ -85,8 +85,6 @@ Particularly as next steps we would like to check for UB when:
 | Discussion and moral support | ![Team][], [lang], [opsem]    |       |
 | Implementation               | @1c3t3a, @vabr-g              |       |
 | Standard reviews             | ![Team][] [compiler], [opsem] |       |
-| Design meeting               | ![Team][] [lang], [opsem]     |       |
-| Lang-team experiment         | ![Team][] [lang]              |       |
 
 ### Definitions
 

--- a/src/2025h1/null-enum-discriminant-debug-checks.md
+++ b/src/2025h1/null-enum-discriminant-debug-checks.md
@@ -80,10 +80,10 @@ Particularly as next steps we would like to check for UB when:
 
 **Owner:** @1c3t3a
 
-| Task                         | Owner(s) or team(s)           | Notes |
-|------------------------------|-------------------------------|-------|
-| Discussion and moral support | ![Team][], [lang], [opsem]    |       |
-| Implementation               | @1c3t3a, @vabr-g              |       |
+| Task                         | Owner(s) or team(s)           | Notes     |
+|------------------------------|-------------------------------|-----------|
+| Discussion and moral support | ![Team][], [lang], [opsem]    |           |
+| Implementation               | @1c3t3a, @vabr-g              |           |
 | Standard reviews             | ![Team][] [compiler], [opsem] | @saethlin |
 
 ### Definitions


### PR DESCRIPTION
cc @RalfJung @nikomatsakis 

While we're at it: I am not entirely sure whether this needs a "Lang team experiment", probably not. I can also remove it if requested.

[Rendered](https://github.com/1c3t3a/rust-project-goals/blob/remove-meeting-request/src/2025h1/null-enum-discriminant-debug-checks.md)