### PR TITLE
Add me as a reviewer on null/enum checks goal

### DIFF
--- a/src/2025h1/null-enum-discriminant-debug-checks.md
+++ b/src/2025h1/null-enum-discriminant-debug-checks.md
@@ -80,13 +80,13 @@ Particularly as next steps we would like to check for UB when:
 
 **Owner:** @1c3t3a
 
-| Task                         | Owner(s) or team(s)           | Notes |
-|------------------------------|-------------------------------|-------|
-| Discussion and moral support | ![Team][], [lang], [opsem]    |       |
-| Implementation               | @1c3t3a, @vabr-g              |       |
-| Standard reviews             | ![Team][] [compiler], [opsem] |       |
-| Design meeting               | ![Team][] [lang], [opsem]     |       |
-| Lang-team experiment         | ![Team][] [lang]              |       |
+| Task                         | Owner(s) or team(s)           | Notes     |
+|------------------------------|-------------------------------|-----------|
+| Discussion and moral support | ![Team][], [lang], [opsem]    |           |
+| Implementation               | @1c3t3a, @vabr-g              |           |
+| Standard reviews             | ![Team][] [compiler], [opsem] | @saethlin |
+| Design meeting               | ![Team][] [lang], [opsem]     |           |
+| Lang-team experiment         | ![Team][] [lang]              |           |
 
 ### Definitions
 


### PR DESCRIPTION
I'm not sure what change to make here, but I figure my name should be recorded prominently. I've been mentoring the implementation a bit and I'm also planning on reviewing the work.

[Rendered](https://github.com/saethlin/rust-project-goals/blob/patch-1/src/2025h1/null-enum-discriminant-debug-checks.md)