### PR TITLE
Call out related teams for libtest-json

### DIFF
--- a/src/2025h1/libtest-json.md
+++ b/src/2025h1/libtest-json.md
@@ -63,7 +63,7 @@ Most of that involves shifting responsibilities from the test harness to the tes
 
 | Task                              | Owner(s) or team(s)       | Notes |
 |-----------------------------------|---------------------------|-------|
-| Discussion and moral support      | ![Team][] [testing-devex] |       |
+| Discussion and moral support      | ![Team][] [testing-devex], [cargo], [libs-api] |       |
 | Prototype harness                 | @epage                    |       |
 | Prototype Cargo reporting support | @epage                    |       |
 | Write stabilization report        | @epage                    |       |


### PR DESCRIPTION
I'd like to vet the design by experimenting with integration within Cargo.
I had assumed the T-cargo members of T-testing-devex would be sufficient but the T-cargo wanted visibility in this, so I'm adding them.

Since I was added T-cargo, I decided to add T-libs-api.  We are working under T-libs-api and this ends with a stabilization report for them but figure if I was adding more, I'd include them as well.

[Rendered](https://github.com/epage/rust-project-goals/blob/cargo/src/2025h1/libtest-json.md)