### PR TITLE
rework template

### DIFF
--- a/rust-project-goals.toml
+++ b/rust-project-goals.toml
@@ -5,6 +5,7 @@
 "Discussion and moral support" = "approve of this direction and be prepared for light discussion on Zulip or elsewhere"
 "Design meeting" = "hold a synchronous meeting to review a proposal and provide feedback (no decision expected)"
 "Stabilization decision" = "reach a decision on a stabilization proposal"
+"Finalize specification text" = "assign a spec team liaison to finalize edits to Rust reference/specification"
 "Prioritized nominations" = "prioritize discussion and resolution of nominated issues"
 "Deploy to production" = "deploy code to production (e.g., on crates.io"
 "Standard reviews" = "review PRs (PRs are not expected to be unduly large or complicated)"

--- a/src/2024h2/async.md
+++ b/src/2024h2/async.md
@@ -1,14 +1,14 @@
 ## Bring the Async Rust experience closer to parity with sync Rust
 
-| Metadata       |                                    |
-|----------------|------------------------------------|
-| Short title    | Async                              |
-| Point of contact | @tmandry            |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
-| Status         | Flagship                           |
-| Tracking issue | [rust-lang/rust-project-goals#105] |
-| Zulip channel  | [#wg-async][channel]               |
+| Metadata         |                                    |
+|------------------|------------------------------------|
+| Short title      | Async                              |
+| Point of contact | @tmandry                           |
+| Teams            | <!-- TEAMS WITH ASKS -->           |
+| Task owners      | <!-- TASK OWNERS -->               |
+| Status           | Flagship                           |
+| Tracking issue   | [rust-lang/rust-project-goals#105] |
+| Zulip channel    | [#wg-async][channel]               |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
 
@@ -187,12 +187,12 @@ Here is a detailed list of the work to be done and who is expected to do it. Thi
 
 ### "Send bound" problem
 
-| Task                   | Owner(s) or team(s)  | Notes         |
-|------------------------|----------------------|---------------|
-| ~~Implementation~~     | ~~@compiler-errors~~ | ![Complete][] |
-| ~~Author RFC~~         | @nikomatsakis        | ![Complete][] |
-| RFC decision           | ![Team][] [lang]     | ![Complete][] |
-| Stabilization decision | ![Team][] [lang]     |               |
+| Task                           | Owner(s) or team(s)  | Notes         |
+|--------------------------------|----------------------|---------------|
+| ~~Implementation~~             | ~~@compiler-errors~~ | ![Complete][] |
+| ~~Author RFC~~                 | @nikomatsakis        | ![Complete][] |
+| RFC decision                   | ![Team][] [lang]     | ![Complete][] |
+| Stabilization decision         | ![Team][] [lang]     |               |
 
 ### Async WG reorganization
 

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -108,7 +108,7 @@ This section defines the specific work items that are planned and who is expecte
 | Finished implementation        | @compiler-errors                                   | ![Complete][] |
 | Standard reviews               | ![Team][] [types], [compiler]                      |               |
 | Author specification 1st draft | TBD (@compiler-errors, @tmandry, or @nikomatsakis) |               |
-| Finalize specification text    | ![Team][] [spec]                                   |               |
+| Finalize specification text    | ![Team][] [spec]                                   | nikomatsakis  |
 | Stabilization decision         | ![Team][] [lang]                                   |               |
 
 ### Unsafe binders
@@ -142,8 +142,6 @@ This section defines the specific work items that are planned and who is expecte
 | Implementation                 | @eholk              |       |
 | Author RFC                     | @eholk              |       |
 | RFC decision                   | ![Team][] [lang]    |       |
-| Author specification 1st draft | @eholk              |       |
-| Finalize specification text    | ![Team][] [spec]    |       |
 
 ### Safe pin projection
 

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -100,38 +100,40 @@ This section defines the specific work items that are planned and who is expecte
 
 ### Return type notation
 
-| Task                    | Owner(s) or team(s)          | Notes         |
-|-------------------------|------------------------------|---------------|
-| Initial implementation  | @compiler-errors             | ![Complete][] |
-| Author RFC              | @nikomatsakis                | ![Complete][] |
-| RFC decision            | ![Team][] [lang]             | ![Complete][] |
-| Finished implementation | @compiler-errors             |               |
-| Standard reviews        | ![Team][] [types] [compiler] |               |
-| Stabilization decision  | ![Team][] [lang]             |               |
+| Task                           | Owner(s) or team(s)                                | Notes         |
+|--------------------------------|----------------------------------------------------|---------------|
+| Initial implementation         | @compiler-errors                                   | ![Complete][] |
+| Author RFC                     | @nikomatsakis                                      | ![Complete][] |
+| RFC decision                   | ![Team][] [lang]                                   | ![Complete][] |
+| Finished implementation        | @compiler-errors                                   | ![Complete][] |
+| Standard reviews               | ![Team][] [types], [compiler]                      |               |
+| Author specification 1st draft | TBD (@compiler-errors, @tmandry, or @nikomatsakis) |               |
+| Finalize specification text    | ![Team][] [spec]                                   |               |
+| Stabilization decision         | ![Team][] [lang]                                   |               |
 
 ### Unsafe binders
 
-| Task                    | Owner(s) or team(s)          | Notes         |
-|-------------------------|------------------------------|---------------|
-| Initial implementation  | @compiler-errors             | Stretch goal  |
-| Author RFC              | @nikomatsakis                | Stretch goal  |
-| RFC decision            | ![Team][] [lang]             | Stretch goal  |
+| Task                   | Owner(s) or team(s) | Notes        |
+|------------------------|---------------------|--------------|
+| Initial implementation | @compiler-errors    | Stretch goal |
+| Author RFC             | @nikomatsakis       | Stretch goal |
+| RFC decision           | ![Team][] [lang]    | Stretch goal |
 
 ### Implementable trait aliases
 
-| Task             | Owner(s) or team(s)          | Notes |
-|------------------|------------------------------|-------|
-| Author RFC       | @tmandry                     |       |
-| Implementation   | @compiler-errors             |       |
-| Standard reviews | ![Team][] [types] [compiler] |       |
-| RFC decision     | ![Team][] [lang] [types]     |       |
+| Task             | Owner(s) or team(s)           | Notes |
+|------------------|-------------------------------|-------|
+| Author RFC       | @tmandry                      |       |
+| Implementation   | @compiler-errors              |       |
+| Standard reviews | ![Team][] [types], [compiler] |       |
+| RFC decision     | ![Team][] [lang] [types]      |       |
 
 ### `async fn` in `dyn Trait`
 
-| Task                 | Owner(s) or team(s)          | Notes        |
-|----------------------|------------------------------|--------------|
-| Lang-team experiment | @nikomatsakis                | (Approved)   |
-| Implementation       | @compiler-errors             | Stretch goal |
+| Task                 | Owner(s) or team(s) | Notes        |
+|----------------------|---------------------|--------------|
+| Lang-team experiment | @nikomatsakis       | (Approved)   |
+| Implementation       | @compiler-errors    | Stretch goal |
 
 ### Pin reborrowing
 
@@ -151,25 +153,25 @@ This section defines the specific work items that are planned and who is expecte
 
 ### Trait for generators (sync)
 
-| Task           | Owner(s) or team(s)         | Notes               |
-|----------------|-----------------------------|---------------------|
-| Implementation | @eholk                      |                     |
-| Author RFC     |                             |                     |
-| RFC decision   | ![Team][] [libs-api] [lang] |                     |
-| Design meeting | ![Team][] [lang]            | 2 meetings expected |
+| Task           | Owner(s) or team(s)          | Notes               |
+|----------------|------------------------------|---------------------|
+| Implementation | @eholk                       |                     |
+| Author RFC     |                              |                     |
+| RFC decision   | ![Team][] [libs-api], [lang] |                     |
+| Design meeting | ![Team][] [lang]             | 2 meetings expected |
 
 ### Trait for async iteration
 
-| Task           | Owner(s) or team(s)         | Notes |
-|----------------|-----------------------------|-------|
-| Design meeting | ![Team][] [lang] [libs-api] |       |
+| Task           | Owner(s) or team(s)          | Notes |
+|----------------|------------------------------|-------|
+| Design meeting | ![Team][] [lang], [libs-api] |       |
 
 ### Dynosaur 1.0
 
-| Task                          | Owner(s) or team(s)            | Notes                 |
-|-------------------------------|--------------------------------|-----------------------|
-| Implementation                | @spastorino                    |                       |
-| Standard reviews              | @tmandry                       |                       |
+| Task             | Owner(s) or team(s) | Notes |
+|------------------|---------------------|-------|
+| Implementation   | @spastorino         |       |
+| Standard reviews | @tmandry            |       |
 
 ### Definitions
 

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -137,11 +137,13 @@ This section defines the specific work items that are planned and who is expecte
 
 ### Pin reborrowing
 
-| Task           | Owner(s) or team(s) | Notes |
-|----------------|---------------------|-------|
-| Implementation | @eholk              |       |
-| Author RFC     | @eholk              |       |
-| RFC decision   | ![Team][] [lang]    |       |
+| Task                           | Owner(s) or team(s) | Notes |
+|--------------------------------|---------------------|-------|
+| Implementation                 | @eholk              |       |
+| Author RFC                     | @eholk              |       |
+| RFC decision                   | ![Team][] [lang]    |       |
+| Author specification 1st draft | @eholk              |       |
+| Finalize specification text    | ![Team][] [spec]    |       |
 
 ### Safe pin projection
 

--- a/src/2025h1/const-trait.md
+++ b/src/2025h1/const-trait.md
@@ -64,7 +64,7 @@ Steps towards the primary goal of doing everything towards stabilization apart f
 | Standard reviews                   | ![Team][] [compiler]           |                                                                 |
 | Design meeting                     | ![Team][] [lang]               | first meeting scheduled for Jan; second meeting may be required |
 | RFC decision                       | ![Team][] [lang]               |                                                                 |
-| RFC secondary review                   | ![Team][] [types]              | Types team needs to validate the approach                       |
+| RFC secondary review               | ![Team][] [types]              | Types team needs to validate the approach                       |
 | Author stabilization report        | @oli-obk                       | stretch goal                                                    |
 
 ### Formalize const-traits in a-mir-formality

--- a/src/2025h1/const-trait.md
+++ b/src/2025h1/const-trait.md
@@ -66,7 +66,7 @@ Steps towards the primary goal of doing everything towards stabilization apart f
 | RFC decision                       | ![Team][] [lang]               |                                                                 |
 | RFC secondary review               | ![Team][] [types]              | Types team needs to validate the approach                       |
 | Author specification 1st draft     | @oli-obk                       |                                                                 |
-| Finalize specification text        | ![Team][] [spec]               |                                                                 |
+| Finalize specification text        | ![Team][] [spec]               | @traviscross                                                    |
 | Author stabilization report        | @oli-obk                       | stretch goal                                                    |
 
 ### Formalize const-traits in a-mir-formality

--- a/src/2025h1/const-trait.md
+++ b/src/2025h1/const-trait.md
@@ -65,6 +65,8 @@ Steps towards the primary goal of doing everything towards stabilization apart f
 | Design meeting                     | ![Team][] [lang]               | first meeting scheduled for Jan; second meeting may be required |
 | RFC decision                       | ![Team][] [lang]               |                                                                 |
 | RFC secondary review               | ![Team][] [types]              | Types team needs to validate the approach                       |
+| Author specification 1st draft     | @oli-obk                       |                                                                 |
+| Finalize specification text        | ![Team][] [spec]               |                                                                 |
 | Author stabilization report        | @oli-obk                       | stretch goal                                                    |
 
 ### Formalize const-traits in a-mir-formality

--- a/src/2025h1/macro-improvements.md
+++ b/src/2025h1/macro-improvements.md
@@ -1,12 +1,12 @@
 # Declarative (`macro_rules!`) macro improvements
 
-| Metadata         |               |
-|:-----------------|---------------|
-| Point of contact | @joshtriplett |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed      |
-| Zulip channel    | N/A           |
+| Metadata         |                          |
+|:-----------------|--------------------------|
+| Point of contact | @joshtriplett            |
+| Teams            | <!-- TEAMS WITH ASKS --> |
+| Task owners      | <!-- TASK OWNERS -->     |
+| Status           | Proposed                 |
+| Zulip channel    | N/A                      |
 
 ## Summary
 
@@ -129,54 +129,60 @@ could reserve such syntax in all editions.
 **Owner / Responsible Reporting Party:** @joshtriplett
 
 
-| Task                                             | Owner(s) or team(s) | Notes                                                                                      |
-|--------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------|
-| Propose discussion session at RustWeek           | @joshtriplett       |                                                                                            |
-| Policy decision                                  | ![Team][] [lang] [wg-macros] | Discussed with @eholk and @vincenzopalazzo; lang would decide whether to delegate specific matters to wg-macros |
+| Task                                   | Owner(s) or team(s)          | Notes                                                                                                           |
+|----------------------------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| Propose discussion session at RustWeek | @joshtriplett                |                                                                                                                 |
+| Policy decision                        | ![Team][] [lang] [wg-macros] | Discussed with @eholk and @vincenzopalazzo; lang would decide whether to delegate specific matters to wg-macros |
 
 ### `macro_rules!` attributes
 
-| Task                                   | Owner(s) or team(s) | Notes |
-|----------------------------------------|---------------------|-------|
-| Author/revise/iterate RFCs             | @joshtriplett       |       |
-| Prioritized nominations                | ![Team][] [lang]    |       |
-| RFC decision                           | ![Team][] [lang]    |       |
-| Implementation of RFC                  | @eholk, @vincenzopalazzo |  |
-| Iterate on design as needed            | @joshtriplett       |       |
-| Inside Rust blog post on attribute macros | @joshtriplett    |       |
-| Process feedback from crate authors    | @joshtriplett       |       |
-| Author stabilization report (if ready) | @joshtriplett       |       |
-| Stabilization decision                 | ![Team][] [lang]    |       |
+| Task                                      | Owner(s) or team(s)      | Notes |
+|-------------------------------------------|--------------------------|-------|
+| Author/revise/iterate RFCs                | @joshtriplett            |       |
+| Prioritized nominations                   | ![Team][] [lang]         |       |
+| RFC decision                              | ![Team][] [lang]         |       |
+| Implementation of RFC                     | @eholk, @vincenzopalazzo |       |
+| Iterate on design as needed               | @joshtriplett            |       |
+| Inside Rust blog post on attribute macros | @joshtriplett            |       |
+| Process feedback from crate authors       | @joshtriplett            |       |
+| Author stabilization report (if ready)    | @joshtriplett            |       |
+| Author specification 1st draft            | @joshtriplett            |       |
+| Finalize specification text               | ![Team][] [spec]         |       |
+| Stabilization decision                    | ![Team][] [lang]         |       |
 
 ### `macro_rules!` derives
 
-| Task                                   | Owner(s) or team(s) | Notes |
-|----------------------------------------|---------------------|-------|
-| Author/revise/iterate RFCs             | @joshtriplett       |       |
-| Prioritized nominations                | ![Team][] [lang]    |       |
-| RFC decision                           | ![Team][] [lang]    |       |
-| Implementation of RFC                  | @eholk, @vincenzopalazzo |  |
-| Iterate on design as needed            | @joshtriplett       |       |
-| Inside Rust blog post on derive macros | @joshtriplett       |       |
-| Process feedback from crate authors    | @joshtriplett       |       |
-| Author stabilization report (if ready) | @joshtriplett       |       |
-| Stabilization decision                 | ![Team][] [lang]    |       |
+| Task                                   | Owner(s) or team(s)      | Notes |
+|----------------------------------------|--------------------------|-------|
+| Author/revise/iterate RFCs             | @joshtriplett            |       |
+| Prioritized nominations                | ![Team][] [lang]         |       |
+| RFC decision                           | ![Team][] [lang]         |       |
+| Implementation of RFC                  | @eholk, @vincenzopalazzo |       |
+| Iterate on design as needed            | @joshtriplett            |       |
+| Inside Rust blog post on derive macros | @joshtriplett            |       |
+| Process feedback from crate authors    | @joshtriplett            |       |
+| Author stabilization report (if ready) | @joshtriplett            |       |
+| Author specification 1st draft         | @joshtriplett            |       |
+| Finalize specification text            | ![Team][] [spec]         |       |
+| Stabilization decision                 | ![Team][] [lang]         |       |
 
 ### Design and iteration for macro fragment fields
 
-| Task                                          | Owner(s) or team(s)          | Notes |
-|-----------------------------------------------|------------------------------|-------|
-| Author initial RFC                            | @joshtriplett                |       |
-| Design meeting                                | ![Team][] [lang]             |       |
-| RFC decision                                  | ![Team][] [lang]             |       |
-| Implementation of RFC                         | @eholk, @vincenzopalazzo     |       |
-| Iterate on design as needed                   | @joshtriplett                |       |
-| Inside Rust blog post on additional capabilities | @joshtriplett             |       |
-| Process feedback from crate authors           | @joshtriplett                |       |
-| Author stabilization report (if ready)        | @joshtriplett                |       |
-| Stabilization decision                        | ![Team][] [lang]             |       |
-| Support lang experiments for fragment fields  | @joshtriplett                |       |
-| Author small RFCs for further fragment fields | @joshtriplett                |       |
+| Task                                             | Owner(s) or team(s)      | Notes |
+|--------------------------------------------------|--------------------------|-------|
+| Author initial RFC                               | @joshtriplett            |       |
+| Design meeting                                   | ![Team][] [lang]         |       |
+| RFC decision                                     | ![Team][] [lang]         |       |
+| Implementation of RFC                            | @eholk, @vincenzopalazzo |       |
+| Iterate on design as needed                      | @joshtriplett            |       |
+| Inside Rust blog post on additional capabilities | @joshtriplett            |       |
+| Process feedback from crate authors              | @joshtriplett            |       |
+| Author stabilization report (if ready)           | @joshtriplett            |       |
+| Author specification 1st draft                   | @joshtriplett            |       |
+| Finalize specification text                      | ![Team][] [spec]         |       |
+| Stabilization decision                           | ![Team][] [lang]         |       |
+| Support lang experiments for fragment fields     | @joshtriplett            |       |
+| Author small RFCs for further fragment fields    | @joshtriplett            |       |
 
 ### Design for macro metavariable constructs
 

--- a/src/2025h1/macro-improvements.md
+++ b/src/2025h1/macro-improvements.md
@@ -136,53 +136,53 @@ could reserve such syntax in all editions.
 
 ### `macro_rules!` attributes
 
-| Task                                      | Owner(s) or team(s)      | Notes |
-|-------------------------------------------|--------------------------|-------|
-| Author/revise/iterate RFCs                | @joshtriplett            |       |
-| Prioritized nominations                   | ![Team][] [lang]         |       |
-| RFC decision                              | ![Team][] [lang]         |       |
-| Implementation of RFC                     | @eholk, @vincenzopalazzo |       |
-| Iterate on design as needed               | @joshtriplett            |       |
-| Inside Rust blog post on attribute macros | @joshtriplett            |       |
-| Process feedback from crate authors       | @joshtriplett            |       |
-| Author stabilization report (if ready)    | @joshtriplett            |       |
-| Author specification 1st draft            | @joshtriplett            |       |
-| Finalize specification text               | ![Team][] [spec]         |       |
-| Stabilization decision                    | ![Team][] [lang]         |       |
+| Task                                      | Owner(s) or team(s)      | Notes    |
+|-------------------------------------------|--------------------------|----------|
+| Author/revise/iterate RFCs                | @joshtriplett            |          |
+| Prioritized nominations                   | ![Team][] [lang]         |          |
+| RFC decision                              | ![Team][] [lang]         |          |
+| Implementation of RFC                     | @eholk, @vincenzopalazzo |          |
+| Iterate on design as needed               | @joshtriplett            |          |
+| Inside Rust blog post on attribute macros | @joshtriplett            |          |
+| Process feedback from crate authors       | @joshtriplett            |          |
+| Author stabilization report (if ready)    | @joshtriplett            |          |
+| Author specification 1st draft            | @joshtriplett            |          |
+| Finalize specification text               | ![Team][] [spec]         | @m-ou-se |
+| Stabilization decision                    | ![Team][] [lang]         |          |
 
 ### `macro_rules!` derives
 
-| Task                                   | Owner(s) or team(s)      | Notes |
-|----------------------------------------|--------------------------|-------|
-| Author/revise/iterate RFCs             | @joshtriplett            |       |
-| Prioritized nominations                | ![Team][] [lang]         |       |
-| RFC decision                           | ![Team][] [lang]         |       |
-| Implementation of RFC                  | @eholk, @vincenzopalazzo |       |
-| Iterate on design as needed            | @joshtriplett            |       |
-| Inside Rust blog post on derive macros | @joshtriplett            |       |
-| Process feedback from crate authors    | @joshtriplett            |       |
-| Author stabilization report (if ready) | @joshtriplett            |       |
-| Author specification 1st draft         | @joshtriplett            |       |
-| Finalize specification text            | ![Team][] [spec]         |       |
-| Stabilization decision                 | ![Team][] [lang]         |       |
+| Task                                   | Owner(s) or team(s)      | Notes    |
+|----------------------------------------|--------------------------|----------|
+| Author/revise/iterate RFCs             | @joshtriplett            |          |
+| Prioritized nominations                | ![Team][] [lang]         |          |
+| RFC decision                           | ![Team][] [lang]         |          |
+| Implementation of RFC                  | @eholk, @vincenzopalazzo |          |
+| Iterate on design as needed            | @joshtriplett            |          |
+| Inside Rust blog post on derive macros | @joshtriplett            |          |
+| Process feedback from crate authors    | @joshtriplett            |          |
+| Author stabilization report (if ready) | @joshtriplett            |          |
+| Author specification 1st draft         | @joshtriplett            |          |
+| Finalize specification text            | ![Team][] [spec]         | @m-ou-se |
+| Stabilization decision                 | ![Team][] [lang]         |          |
 
 ### Design and iteration for macro fragment fields
 
-| Task                                             | Owner(s) or team(s)      | Notes |
-|--------------------------------------------------|--------------------------|-------|
-| Author initial RFC                               | @joshtriplett            |       |
-| Design meeting                                   | ![Team][] [lang]         |       |
-| RFC decision                                     | ![Team][] [lang]         |       |
-| Implementation of RFC                            | @eholk, @vincenzopalazzo |       |
-| Iterate on design as needed                      | @joshtriplett            |       |
-| Inside Rust blog post on additional capabilities | @joshtriplett            |       |
-| Process feedback from crate authors              | @joshtriplett            |       |
-| Author stabilization report (if ready)           | @joshtriplett            |       |
-| Author specification 1st draft                   | @joshtriplett            |       |
-| Finalize specification text                      | ![Team][] [spec]         |       |
-| Stabilization decision                           | ![Team][] [lang]         |       |
-| Support lang experiments for fragment fields     | @joshtriplett            |       |
-| Author small RFCs for further fragment fields    | @joshtriplett            |       |
+| Task                                             | Owner(s) or team(s)      | Notes    |
+|--------------------------------------------------|--------------------------|----------|
+| Author initial RFC                               | @joshtriplett            |          |
+| Design meeting                                   | ![Team][] [lang]         |          |
+| RFC decision                                     | ![Team][] [lang]         |          |
+| Implementation of RFC                            | @eholk, @vincenzopalazzo |          |
+| Iterate on design as needed                      | @joshtriplett            |          |
+| Inside Rust blog post on additional capabilities | @joshtriplett            |          |
+| Process feedback from crate authors              | @joshtriplett            |          |
+| Author stabilization report (if ready)           | @joshtriplett            |          |
+| Author specification 1st draft                   | @joshtriplett            |          |
+| Finalize specification text                      | ![Team][] [spec]         | @m-ou-se |
+| Stabilization decision                           | ![Team][] [lang]         |          |
+| Support lang experiments for fragment fields     | @joshtriplett            |          |
+| Author small RFCs for further fragment fields    | @joshtriplett            |          |
 
 ### Design for macro metavariable constructs
 

--- a/src/2025h1/restrictions.md
+++ b/src/2025h1/restrictions.md
@@ -50,7 +50,7 @@ high level, but are not the focus of this project goal.
 | Prioritized nominations                 | ![Team][] [lang]     | for unresolved questions, including syntax |
 | Author stabilization report             | @jhpratt             |                                            |
 | Author specification 1st draft          | @jhpratt             |                                            |
-| Finalize specification text             | ![Team][] [spec]     |                                            |
+| Finalize specification text             | ![Team][] [spec]     | @nikomatsakis                              |
 | Stabilization decision                  | ![Team][] [lang]     |                                            |
 | Inside Rust blog post inviting feedback | @jhpratt             | feedback on syntax if no team consensus    |
 

--- a/src/2025h1/restrictions.md
+++ b/src/2025h1/restrictions.md
@@ -1,12 +1,12 @@
 # Implement restrictions, prepare for stabilization
 
-| Metadata         |                   |
-|:-----------------|-------------------|
-| Point of contact | @jhpratt          |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed          |
-| Zulip channel    | N/A               |
+| Metadata         |                          |
+|:-----------------|--------------------------|
+| Point of contact | @jhpratt                 |
+| Teams            | <!-- TEAMS WITH ASKS --> |
+| Task owners      | <!-- TASK OWNERS -->     |
+| Status           | Proposed                 |
+| Zulip channel    | N/A                      |
 
 [rfc]: https://rust-lang.github.io/rfcs/3323-restrictions.html
 [pr]: https://github.com/rust-lang/rust/pull/106074
@@ -49,6 +49,8 @@ high level, but are not the focus of this project goal.
 | Standard reviews                        | ![Team][] [compiler] |                                            |
 | Prioritized nominations                 | ![Team][] [lang]     | for unresolved questions, including syntax |
 | Author stabilization report             | @jhpratt             |                                            |
+| Author specification 1st draft          | @jhpratt             |                                            |
+| Finalize specification text             | ![Team][] [spec]     |                                            |
 | Stabilization decision                  | ![Team][] [lang]     |                                            |
 | Inside Rust blog post inviting feedback | @jhpratt             | feedback on syntax if no team consensus    |
 

--- a/src/2025h1/spec-testing.md
+++ b/src/2025h1/spec-testing.md
@@ -5,7 +5,7 @@
 | Point of contact | @chorman0773       |
 | Teams | <!-- TEAMS WITH ASKS --> |
 | Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed           |
+| Status           | Not accepted           |
 | Zulip channel    | [#t-spec][channel] |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/399173-t-spec

--- a/src/2025h1/unsafe-fields.md
+++ b/src/2025h1/unsafe-fields.md
@@ -86,7 +86,7 @@ The design of `unsafe` fields is guided by three axioms:
 | Design meeting                 | ![Team][] [lang]     |                                |
 | RFC decision                   | ![Team][] [lang]     |                                |
 | Author specification 1st draft | @jswrenn             |                                |
-| Finalize specification text    | ![Team][] [spec]     |                                |
+| Finalize specification text    | ![Team][] [spec]     | @ehuss                       |
 | Author stabilization report    | @jswrenn             |                                |
 
 [Zulip]: https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/unsafe.20fields.20RFC

--- a/src/2025h1/unsafe-fields.md
+++ b/src/2025h1/unsafe-fields.md
@@ -1,12 +1,12 @@
 # Unsafe Fields
 
-| Metadata         |                      |
-|:-----------------|----------------------|
-| Point of contact | @jswrenn             |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
-| Status           | Proposed             |
-| Zulip channel    | N/A                  |
+| Metadata         |                          |
+|:-----------------|--------------------------|
+| Point of contact | @jswrenn                 |
+| Teams            | <!-- TEAMS WITH ASKS --> |
+| Task owners      | <!-- TASK OWNERS -->     |
+| Status           | Proposed                 |
+| Zulip channel    | N/A                      |
 
 ## Summary
 
@@ -77,15 +77,17 @@ The design of `unsafe` fields is guided by three axioms:
 
 **Owner:** @jswrenn
 
-| Task                         | Owner(s) or team(s)  | Notes                          |
-|------------------------------|----------------------|--------------------------------|
-| Discussion and moral support | ![Team][] [lang]     | [Zulip]                        |
-| Author RFC                   | @jhpratt             | [RFC3458], [Living Design Doc] |
-| Implementation               | @veluca93            |                                |
-| Standard reviews             | ![Team][] [compiler] |                                |
-| Design meeting               | ![Team][] [lang]     |                                |
-| RFC decision                 | ![Team][] [lang]     |                                |
-| Author stabilization report  | @jswrenn             |                                |
+| Task                           | Owner(s) or team(s)  | Notes                          |
+|--------------------------------|----------------------|--------------------------------|
+| Discussion and moral support   | ![Team][] [lang]     | [Zulip]                        |
+| Author RFC                     | @jhpratt             | [RFC3458], [Living Design Doc] |
+| Implementation                 | @veluca93            |                                |
+| Standard reviews               | ![Team][] [compiler] |                                |
+| Design meeting                 | ![Team][] [lang]     |                                |
+| RFC decision                   | ![Team][] [lang]     |                                |
+| Author specification 1st draft | @jswrenn             |                                |
+| Finalize specification text    | ![Team][] [spec]     |                                |
+| Author stabilization report    | @jswrenn             |                                |
 
 [Zulip]: https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/unsafe.20fields.20RFC
 [RFC3458]: https://github.com/rust-lang/rfcs/pull/3458

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -67,7 +67,7 @@
 
 ### Design language feature to solve problem X
 
-> *Some goals propose to design a feature to solve a problem. Typically the outcome from this goal is an draft or accepted RFC. If you would like to work on an experimental implementation in-tree before an RFC is accepted, you can create a [lang team experiment](https://lang-team.rust-lang.org/how_to/experiment.html), but not that a trusted contributor is required.*
+> *Some goals propose to design a feature to solve a problem. Typically the outcome from this goal is an draft or accepted RFC. If you would like to work on an experimental implementation in-tree before an RFC is accepted, you can create a [lang team experiment](https://lang-team.rust-lang.org/how_to/experiment.html), but note that a trusted contributor is required.*
 
 | Task                 | Owner(s) or team(s)                | Notes                                                               |
 |----------------------|------------------------------------|---------------------------------------------------------------------|

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -77,7 +77,7 @@
 | RFC decision         | ![Team][] [lang]                   |                                                                     |
 | Secondary RFC review | ![Team][] [types]                  | request bandwidth from a second team, most features don't need this |
 
-### Implement flanguage eature X
+### Implement language feature X
 
 > *If there is an accepted RFC, or you are doing a [lang-team experiment](https://lang-team.rust-lang.org/how_to/experiment.html), you commonly need someone to write the code, support from the compiler to review your PRs, and possibly lang-team design meetings to review interesting design questions. Once implementation completes we recommend a call for testing blog post.*
 

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -54,6 +54,8 @@
 
 > *This section lists out the work to be done and the asks from Rust teams. Every row in the table should either correspond to something done by a contributor or something asked of a team.*
 >
+> *For most goals, a single table will suffice, but you can also add subsections with `###`. We give several example subsections below that also demonstrate the most common kinds of goals. Remember that the items in the table only corresponds to what you plan to do over the next 6 months.*
+>
 > *For items done by a contributor, list the contributor, or ![Heap wanted][] if you don't yet know who will do it. The owner is ideally identified as a github username like `@ghost`.*
 >
 > *For items asked of teams, list ![Team][] and the name of the team, e.g. `![Team][] [compiler]` or `![Team][] [compiler], [lang]` (note the trailing `[]` in `![Team][]`, that is needed for markdown to parse correctly). For team asks, the "task" must be one of the tasks defined in [rust-project-goals.toml](../rust-project-goals.toml) or `cargo rpg check` will error.*
@@ -63,21 +65,49 @@
 | Discussion and moral support | ![Team][] [cargo]   |       |
 | Do the work                  | *owner*             |       |
 
-### Stabilize feature X
+### Design language feature to solve problem X
 
-> *If you have a complex goal, you can include subsections for different parts of it, each with their own table. Must goals do not need this and can make do with a single table. The table in this section also lists the full range of "asks" for a typical language feature; feel free to copy some subset of them into your main table if you are primarily proposing a single feature (note that most features don't need all the entries below).*
+> *Some goals propose to design a feature to solve a problem. Typically the outcome from this goal is an draft or accepted RFC. If you would like to work on an experimental implementation in-tree before an RFC is accepted, you can create a [lang team experiment](https://lang-team.rust-lang.org/how_to/experiment.html), but not that a trusted contributor is required.*
 
-| Task                        | Owner(s) or team(s)                | Notes                                                         |
-|-----------------------------|------------------------------------|---------------------------------------------------------------|
-| Lang-team experiment        | ![Team][] [lang]                   | allows coding pre-RFC; only for trusted contributors          |
-| Author RFC                  | *Goal point of contact, typically* |                                                               |
-| Implementation              | *Goal point of contact, typically* |                                                               |
-| Standard reviews            | ![Team][] [compiler]               |                                                               |
-| Design meeting              | ![Team][] [lang]                   |                                                               |
-| RFC decision                | ![Team][] [lang]                   |                                                               |
-| Secondary RFC review        | ![Team][] [lang]                   | most features don't need this                                 |
-| Author stabilization report | *Goal point of contact, typically* |                                                               |
-| Stabilization decision      | ![Team][] [lang]                   | it's rare to author rfc, implement, AND stabilize in 6 months |
+| Task                 | Owner(s) or team(s)                | Notes                                                               |
+|----------------------|------------------------------------|---------------------------------------------------------------------|
+| Lang-team experiment | ![Team][] [lang]                   | allows coding pre-RFC; only for trusted contributors                |
+| Author RFC           | *Goal point of contact, typically* |                                                                     |
+| Design meeting       | ![Team][] [lang]                   |                                                                     |
+| RFC decision         | ![Team][] [lang]                   |                                                                     |
+| Secondary RFC review | ![Team][] [types]                  | request bandwidth from a second team, most features don't need this |
+
+### Implement flanguage eature X
+
+> *If there is an accepted RFC, or you are doing a [lang-team experiment](https://lang-team.rust-lang.org/how_to/experiment.html), you commonly need someone to write the code, support from the compiler to review your PRs, and possibly lang-team design meetings to review interesting design questions. Once implementation completes we recommend a call for testing blog post.*
+
+| Task                              | Owner(s) or team(s)                | Notes |
+|-----------------------------------|------------------------------------|-------|
+| Implementation                    | *Goal point of contact, typically* |       |
+| Standard reviews                  | ![Team][] [compiler]               |       |
+| Design meeting                    | ![Team][] [lang]                   |       |
+| Author call for testing blog post | *Goal point of contact, typically* |       |
+
+### Stabilize language feature X
+
+> *If the feature has been RFC'd and implemented and experiences are positive, [stabilization](https://rustc-dev-guide.rust-lang.org/stabilization_guide.html) may be the right next step. In this case, you will need to author a first draft of text for the Rust reference and make a Team Ask to request someone from the the spec team to adapt that text for final inclusion. You will also need to author a stabilization report.
+
+| Task                           | Owner(s) or team(s)                | Notes |
+|--------------------------------|------------------------------------|-------|
+| Author specification 1st draft | *Goal point of contact, typically* |       |
+| Finalize specification text    | ![Team][] [spec]                   |       |
+| Author stabilization report    | *Goal point of contact, typically* |       |
+| Author stabilization PR        | *Goal point of contact, typically* |       |
+| Stabilization decision         | ![Team][] [lang]                   |       |
+
+### Stabilize library feature
+
+> *Standard library features follow the [libs-api stabilization process](https://rustc-dev-guide.rust-lang.org/stability.html#stabilizing-a-library-feature). 
+
+| Task                           | Owner(s) or team(s)                | Notes |
+|--------------------------------|------------------------------------|-------|
+| Author stabilization PR        | *Goal point of contact, typically* |       |
+| Stabilization decision         | ![Team][] [libs-api]               |       |
 
 ### Definitions
 


### PR DESCRIPTION
Rework the template to better identify common groups of asks and in particular to add a new item for spec team process

[Rendered](https://github.com/nikomatsakis/rust-project-goals-ndm/blob/assign-spec-reviewers/src/2024h2/async.md)