### PR TITLE
add types team to async deliverables

### DIFF
--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -1,7 +1,7 @@
 # Bring the Async Rust experience closer to parity with sync Rust
 
 | Metadata         |                                    |
-|:-----------------|------------------------------------|
+| :--------------- | ---------------------------------- |
 | Point of contact | @tmandry                           |
 | Teams            | <!-- TEAMS WITH ASKS -->           |
 | Task owners      | <!-- TASK OWNERS -->               |
@@ -95,58 +95,60 @@ This section defines the specific work items that are planned and who is expecte
 ### Overall program management
 
 | Task                 | Owner(s) or team(s) | Notes |
-|----------------------|---------------------|-------|
+| -------------------- | ------------------- | ----- |
 | AFIT story blog post | @tmandry            |       |
 
 ### Return type notation
 
 | Task                           | Owner(s) or team(s)                                | Notes         |
-|--------------------------------|----------------------------------------------------|---------------|
+| ------------------------------ | -------------------------------------------------- | ------------- |
 | Initial implementation         | @compiler-errors                                   | ![Complete][] |
 | Author RFC                     | @nikomatsakis                                      | ![Complete][] |
 | RFC decision                   | ![Team][] [lang]                                   | ![Complete][] |
 | Finished implementation        | @compiler-errors                                   | ![Complete][] |
 | Standard reviews               | ![Team][] [types], [compiler]                      |               |
+| Author stabilization report    | @compiler-errors                                   |               |
 | Author specification 1st draft | TBD (@compiler-errors, @tmandry, or @nikomatsakis) |               |
 | Finalize specification text    | ![Team][] [spec]                                   | nikomatsakis  |
-| Stabilization decision         | ![Team][] [lang]                                   |               |
+| Stabilization decision         | ![Team][] [lang], [types]                          |               |
 
 ### Unsafe binders
 
-| Task                   | Owner(s) or team(s) | Notes        |
-|------------------------|---------------------|--------------|
-| Initial implementation | @compiler-errors    | Stretch goal |
-| Author RFC             | @nikomatsakis       | Stretch goal |
-| RFC decision           | ![Team][] [lang]    | Stretch goal |
+| Task                   | Owner(s) or team(s)       | Notes        |
+| ---------------------- | ------------------------- | ------------ |
+| Initial implementation | @compiler-errors          | Stretch goal |
+| Author RFC             | @nikomatsakis             | Stretch goal |
+| RFC decision           | ![Team][] [lang], [types] | Stretch goal |
 
 ### Implementable trait aliases
 
 | Task             | Owner(s) or team(s)           | Notes |
-|------------------|-------------------------------|-------|
+| ---------------- | ----------------------------- | ----- |
 | Author RFC       | @tmandry                      |       |
 | Implementation   | @compiler-errors              |       |
 | Standard reviews | ![Team][] [types], [compiler] |       |
-| RFC decision     | ![Team][] [lang] [types]      |       |
+| RFC decision     | ![Team][] [lang], [types]     |       |
 
 ### `async fn` in `dyn Trait`
 
 | Task                 | Owner(s) or team(s) | Notes        |
-|----------------------|---------------------|--------------|
+| -------------------- | ------------------- | ------------ |
 | Lang-team experiment | @nikomatsakis       | (Approved)   |
 | Implementation       | @compiler-errors    | Stretch goal |
 
 ### Pin reborrowing
 
-| Task                           | Owner(s) or team(s) | Notes |
-|--------------------------------|---------------------|-------|
-| Implementation                 | @eholk              |       |
-| Author RFC                     | @eholk              |       |
-| RFC decision                   | ![Team][] [lang]    |       |
+| Task             | Owner(s) or team(s) | Notes |
+| ---------------- | ------------------- | ----- |
+| Implementation   | @eholk              |       |
+| Author RFC       | @eholk              |       |
+| RFC decision     | ![Team][] [lang]    |       |
+| Secondary review | ![Team][] [types]   |       |
 
 ### Safe pin projection
 
 | Task                 | Owner(s) or team(s) | Notes        |
-|----------------------|---------------------|--------------|
+| -------------------- | ------------------- | ------------ |
 | Lang-team experiment | ![Team][] [lang]    |              |
 | Implementation       |                     | Stretch goal |
 | Design meeting       | ![Team][] [lang]    | Stretch goal |
@@ -154,7 +156,7 @@ This section defines the specific work items that are planned and who is expecte
 ### Trait for generators (sync)
 
 | Task           | Owner(s) or team(s)          | Notes               |
-|----------------|------------------------------|---------------------|
+| -------------- | ---------------------------- | ------------------- |
 | Implementation | @eholk                       |                     |
 | Author RFC     |                              |                     |
 | RFC decision   | ![Team][] [libs-api], [lang] |                     |
@@ -163,13 +165,13 @@ This section defines the specific work items that are planned and who is expecte
 ### Trait for async iteration
 
 | Task           | Owner(s) or team(s)          | Notes |
-|----------------|------------------------------|-------|
+| -------------- | ---------------------------- | ----- |
 | Design meeting | ![Team][] [lang], [libs-api] |       |
 
 ### Dynosaur 1.0
 
 | Task             | Owner(s) or team(s) | Notes |
-|------------------|---------------------|-------|
+| ---------------- | ------------------- | ----- |
 | Implementation   | @spastorino         |       |
 | Standard reviews | @tmandry            |       |
 

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -143,7 +143,7 @@ This section defines the specific work items that are planned and who is expecte
 | Implementation   | @eholk              |       |
 | Author RFC       | @eholk              |       |
 | RFC decision     | ![Team][] [lang]    |       |
-| Secondary review | ![Team][] [types]   |       |
+| RFC secondary review | ![Team][] [types]   |       |
 
 ### Safe pin projection
 


### PR DESCRIPTION
cc @lcnr @jackh726 -- 

from [this comment](https://github.com/rust-lang/rfcs/pull/3764#issuecomment-2623216811)

[Rendered](https://github.com/nikomatsakis/rust-project-goals-ndm/blob/types-team-async-deliverables/src/2025h1/async.md)