### PR TITLE
Check that `gh` is installed and document it's needed

### DIFF
--- a/crates/rust-project-goals-cli/src/rfc.rs
+++ b/crates/rust-project-goals-cli/src/rfc.rs
@@ -109,6 +109,14 @@ pub fn generate_issues(
     commit: bool,
     sleep: u64,
 ) -> anyhow::Result<()> {
+    // Verify the `gh` client is installed to compute which actions need to be taken in the repo.
+    let sanity_check = Command::new("gh").arg("--version").output();
+    if sanity_check.is_err() {
+        return Err(anyhow::anyhow!(
+            "The github `gh` client is missing and needs to be installed and configured with a token."
+        ));
+    }
+
     // Hacky but works: we loop because after creating the issue, we sometimes have additional sync to do,
     // and it's easier this way.
     loop {

--- a/src/admin/commands.md
+++ b/src/admin/commands.md
@@ -1,3 +1,5 @@
 # Commands
 
 The `cargo rpg` command is a CLI for manipulating and checking project goals. This section provides a reference describing (some of) the ability commands. You can also try `cargo rpg --help` to get a summary.
+
+Note that this relies on the [`gh` client](https://github.com/cli/cli), which needs to be installed and configured with a token (for example using `gh auth login`).


### PR DESCRIPTION
This checks that `gh` is actually installed before running it in `cargo rpg issues` and documents that it's needed. (Otherwise things just fail with a "file not found" error.)

[Rendered](https://github.com/lqd/rust-project-goals/blob/requirements/src/admin/commands.md)