### PR TITLE
keep the existing tracking issue text when updating it

### DIFF
--- a/crates/rust-project-goals-cli/src/rfc.rs
+++ b/crates/rust-project-goals-cli/src/rfc.rs
@@ -361,9 +361,19 @@ fn initialize_issues<'doc>(
 
                 let link_text = goal_document_link(timeframe, &desired_issue.goal_document);
                 if !existing_issue.body.contains(&link_text) {
+                    // Let's update the tracking issue to the new goal description, while keeping
+                    // the old text in case we need it. It's surprisingly hard to get out of GH
+                    // otherwise.
+                    let body = format!(
+                        "{desired_body}\n---\nNote: we have updated the body to match the \
+                         {timeframe} goal. Your original text is preserved below. \
+                         <details>\n{existing_body}\n</details>",
+                        desired_body = desired_issue.body,
+                        existing_body = existing_issue.body,
+                    );
                     actions.insert(GithubAction::UpdateIssueBody {
                         number: existing_issue.number,
-                        body: desired_issue.body,
+                        body,
                     });
                 }
 


### PR DESCRIPTION
As discussed in https://rust-lang.zulipchat.com/#narrow/channel/478266-project-goals.2Fmeta/topic/updating.202025h1.20OPs this PR changes the tracking issue automation when updating a continuing project goal: we keep the old body text around instead of overwriting it. 

It can be useful sometimes if the tasks are updated, compared to the goal markdown description: the latter feels more static, and set when opening the PR at the beginning of a project goal period. This tracking issue body text is surprisingly hard to get out of github otherwise.