### PR TITLE
A handful of monthly post fixes

### DIFF
--- a/crates/rust-project-goals-cli-llm/src/updates.rs
+++ b/crates/rust-project-goals-cli-llm/src/updates.rs
@@ -162,7 +162,9 @@ fn tldr(
     _issue_id: &IssueId,
     comments: &mut Vec<ExistingGithubComment>,
 ) -> anyhow::Result<Option<String>> {
-    let Some(index) = comments.iter().position(|c| c.body.starts_with(TLDR)) else {
+    // `comments` are sorted by creation date in an ascending order, so we look for the most recent
+    // TL;DR comment from the end.
+    let Some(index) = comments.iter().rposition(|c| c.body.starts_with(TLDR)) else {
         return Ok(None);
     };
 

--- a/crates/rust-project-goals-cli-llm/src/updates.rs
+++ b/crates/rust-project-goals-cli-llm/src/updates.rs
@@ -196,10 +196,11 @@ fn help_wanted(
         while lines.peek().is_some() {
             while let Some(line) = lines.next() {
                 if let Some(c) = HELP_WANTED.captures(line) {
-                    help_wanted.push(HelpWanted {
-                        text: c["text"].to_string(),
-                    });
-                    break;
+                    let text = c["text"].trim().to_string();
+                    if !text.is_empty() {
+                        help_wanted.push(HelpWanted { text });
+                        break;
+                    }
                 }
             }
 

--- a/crates/rust-project-goals-cli-llm/src/updates.rs
+++ b/crates/rust-project-goals-cli-llm/src/updates.rs
@@ -125,7 +125,7 @@ async fn prepare_goals(
         let details_summary = match comments.len() {
             0 => String::from("No detailed updates available."),
             1 => String::from("1 detailed update available."),
-            len => format!("{len} detailed updates availabled."),
+            len => format!("{len} detailed updates available."),
         };
         result.push(UpdatesGoal {
             title: title.clone(),

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -104,7 +104,7 @@ pub fn is_just(re: &Regex, s: &str) -> bool {
 lazy_static! {
     /// If a line within a comment begins with this text, it will be considered a request for help
     pub static ref HELP_WANTED: Regex =
-        Regex::new(r"^(?i:help wanted:|\*\*help wanted:\*\*) (?P<text>.*)")
+        Regex::new(r"^[*-]?\s*(?i:help wanted:|\*\*help wanted:\*\*) (?P<text>.*)")
             .unwrap();
 }
 

--- a/src/2025h1/cargo-script.md
+++ b/src/2025h1/cargo-script.md
@@ -5,7 +5,7 @@
 | Point of contact | @epage                                   |
 | Teams            | <!-- TEAMS WITH ASKS -->                                                         |
 | Task owners        | <!-- TASK OWNERS -->               |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Tracking issue | [rust-lang/rust-project-goals#119] |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
 

--- a/src/admin/author_updates.md
+++ b/src/admin/author_updates.md
@@ -8,7 +8,7 @@ Triagebot can ping project-goal owners for updates. To use it, go to Zulip and e
 @triagebot ping-goals 14 Oct-21
 ```
 
-The first number (14) is a threshold, it is typically set to the current day of the month (e.g., the above command assumes it is Oct 14). It means "if they have posted a comment in the last 14 days, don't bug them". 
+The first number (14) is a threshold, it is typically set to the current day of the month (e.g., the above command assumes it is Oct 14). It means "if they have posted a comment in the last 14 days, don't bug them".
 
 The second string ("Oct-21") is the deadline for updates to be included.
 
@@ -16,13 +16,4 @@ We need to improve this UI.
 
 ## Filling out the template
 
-Run the `cargo rpg updates` command to create the blog post template. If running from within vscode, the `--vscode` command will open the result in a fresh tab, which is convenient. Otherwise, use `--output-file $file.md` to create a new file.
-
-The template will be filled in with the list of flagship goals. Each flagship goal will have their [Why this goal?](./merge_rfc.md#author-the-why-this-goal-sections-for-the-flagship-goals) section auto-inserted from the corresponding tracking issue.
-
-The template will also include the detailed list of updates in a `<details>` section as well as any TL;DR comments left by users.
-
-The update template itself is maintained with handlebars, you will find it [here](https://github.com/rust-lang/rust-project-goals/blob/main/templates/updates.hbs).
-
-
-
+After the updates have been published, they can be summarized in a monthly blog post, as described in [this dedicated chapter](./updates.md).

--- a/src/admin/updates.md
+++ b/src/admin/updates.md
@@ -6,18 +6,19 @@ Usage:
 > cargo rpg updates --help
 ```
 
-The `updates` command generates the starting point for a monthly blog post. The output is based on the handlebars templates found in the `templates` directory. The command you probably want most often is something like this
+Run the `cargo rpg updates` command to create the blog post template. If running from within vscode, the `--vscode` command will open the result in a fresh tab, which is convenient. Otherwise, use `--output-file $file.md` to create a new file.
+
+The template will be filled in with the list of flagship goals. Each flagship goal will have their [Why this goal?](./merge_rfc.md#author-the-why-this-goal-sections-for-the-flagship-goals) section auto-inserted from the corresponding tracking issue.
+
+The template will also include the detailed list of updates in a `<details>` section as well as any TL;DR comments left by users.
+
+The update template itself is maintained with handlebars, you will find it [here](https://github.com/rust-lang/rust-project-goals/blob/main/templates/updates.hbs).
+
+
+This command can also take optional dates to control which comments and updates in the given date range are included in the blog post. This is usually needed to correctly set the starting date right after the previous month's blog post.
+
+For example,
 
 ```
-> cargo rpg updates YYYYhN --vscode
+> cargo rpg updates 2025h1 2025-03-01
 ```
-
-which will open the blogpost in a tab in VSCode. This makes it easy to copy-and-paste over to the main Rust blog.
-
-## Blog post starting point
-
-The blog post starting point is based on the handlebars template in `templates/updates.hbs`.
-
-## Configuring the LLM
-
-The `updates` command makes use of an LLM hosted on AWS Bedrock to summarize people's comments.  You will need to run `aws configure` and login with some default credentials. You can skip the LLM by providing the `--quick` command-line option, but then you have to generate your own text, which can be pretty tedious.

--- a/templates/updates.hbs
+++ b/templates/updates.hbs
@@ -7,7 +7,7 @@ The Rust project is currently working towards a [slate of {{goal_count}} project
 
 <!-- markdown separator --> 
 
-**Why this goal?** {{why_this_goal}}
+**Why this goal?** {{{why_this_goal}}}
 
 **What has happened?** {{{tldr}}}
 

--- a/templates/updates.hbs
+++ b/templates/updates.hbs
@@ -33,7 +33,7 @@ The Rust project is currently working towards a [slate of {{goal_count}} project
 {{#each help_wanted}}
 
 <!-- markdown separator --> 
-![Help wanted](https://img.shields.io/badge/Help%20wanted-yellow) {{{text}}}
+*Help wanted:* {{{text}}}
 <!-- markdown separator --> 
 
 {{/each}}


### PR DESCRIPTION
A few fixes for some of the issues I mentioned [on zulip](https://rust-lang.zulipchat.com/#narrow/channel/478266-project-goals.2Fmeta/topic/2025h1.20mar.20blog.20post/near/507806829).

- some double escaping
- replace the "Help needed" image causing the broken layout on the rust blog with just text
- a silly typo on my part
- looking for the most recent TL;DR comment was incorrect 
- the documentation for `cargo rpg updates` was outdated/duplicated, and I've also documented the start date which is always important when generating the blog post.
- fix the "Help wanted" regex to allow for the option list markers that are part of the suggested update template pings
- ignore empty "Help wanted" updates since that happened

This also fixes the status of the cargo script goal — though I think I fixed the 2025h1 goal count for the monthly post when fixing its GH milestone rather than via this status, but this change should fix the goal count on the website itself.

[Rendered](https://github.com/lqd/rust-project-goals/blob/monthly-fixes/src/2025h1/cargo-script.md)