### PR TITLE
Fix `mdbook build` error preventing deploys

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -33,7 +33,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.40
+      MDBOOK_VERSION: 0.4.43
     steps:
       - uses: actions/checkout@v4
       - name: Install mdBook

--- a/book.toml
+++ b/book.toml
@@ -7,6 +7,9 @@ title = "Rust Project Goals"
 
 [preprocessor.goals]
 command = "cargo run -p mdbook-goals --"
+ignore_users = [
+    "@triagebot",
+]
 
 [preprocessor.goals.links]
 "Help wanted" = "https://img.shields.io/badge/Help%20wanted-yellow"
@@ -22,11 +25,6 @@ command = "cargo run -p mdbook-goals --"
 
 [preprocessor.goals.users]
 "@Nadrieril" = "@Nadrieril"
-
-preprocessor.goals.ignore_users = [
-    "@triagebot",
-]
-
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/rust-project-goals"


### PR DESCRIPTION
Deploys aren't working right now. I don't know when the issue started or what caused it, but it must be recent-ish.

Example GHA failure [here](https://github.com/rust-lang/rust-project-goals/actions/runs/14337368276/job/40187794862):

```
Error: user name `preprocessor` does not start with `@`
Error: -08 15:25:40 [ERROR] (mdbook::utils): Error: The "goals" preprocessor exited unsuccessfully with exit status: 1 status
error: Recipe `build` failed on line 8 with exit code 101
```

There's a `preprocessor.goals.ignore_users` value in the `users` config, so it's seen as a user in the users config, and causes an error. From the preprocessor code, it looks like it should be a separate key in the config root. This PR does that. (I don't know what the ignoring users code does or if it works, this PR just fixes `mdbook build`)

In the logs above, there's also a warning about the version of mdbook `Warning: The goals plugin was built against version 0.4.43 of mdbook, but we're being called from version 0.4.40`, so I've also bumped the GHA one to 0.4.43.

(From the logs, I've also noticed there's a `cargo rpg json 2024h2 --json-path src/api/2024h2.json` step in the justfile, but I don't know what it does and if it needs to be updated for 2025h1?)

