### PR TITLE
Add span tracking to allow emitting diagnostics everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "atomic-waker"
@@ -338,6 +338,33 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -585,6 +612,16 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1113,6 +1150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1356,7 @@ dependencies = [
  "rust-project-goals",
  "semver",
  "serde_json",
+ "spanned",
 ]
 
 [[package]]
@@ -1563,6 +1607,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
@@ -1984,6 +2034,7 @@ dependencies = [
  "rust_team_data",
  "serde",
  "serde_json",
+ "spanned",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -2003,6 +2054,7 @@ dependencies = [
  "rust-project-goals-json",
  "serde",
  "serde_json",
+ "spanned",
  "walkdir",
 ]
 
@@ -2228,6 +2280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2339,17 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spanned"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8e76fd7aeee255ddaa885b9de506484b21cbd458ae9d04d1b24851e82ee58a"
+dependencies = [
+ "anyhow",
+ "bstr",
+ "color-eyre",
 ]
 
 [[package]]
@@ -2439,6 +2511,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2654,6 +2735,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2763,6 +2866,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/mdbook-goals/Cargo.toml
+++ b/crates/mdbook-goals/Cargo.toml
@@ -11,3 +11,4 @@ regex = "1.11.1"
 rust-project-goals = { version = "0.1.0", path = "../rust-project-goals" }
 semver = "1.0.23"
 serde_json = "1.0.133"
+spanned = "0.4.0"

--- a/crates/mdbook-goals/src/mdbook_preprocessor.rs
+++ b/crates/mdbook-goals/src/mdbook_preprocessor.rs
@@ -16,6 +16,7 @@ use rust_project_goals::{
     goal::{self, GoalDocument, Status, TeamAsk},
     re, team,
 };
+use spanned::Spanned;
 
 const LINKS: &str = "links";
 const LINKIFIERS: &str = "linkifiers";
@@ -293,18 +294,18 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         }
         let config = Configuration::get();
         let rows = std::iter::once(vec![
-            "Ask".to_string(),
-            "aka".to_string(),
-            "Description".to_string(),
+            Spanned::here("Ask".to_string()),
+            Spanned::here("aka".to_string()),
+            Spanned::here("Description".to_string()),
         ])
         .chain(config.team_asks.iter().map(|(name, details)| {
             vec![
-                format!("{name:?}"),
-                details.short.to_string(),
-                details.about.to_string(),
+                Spanned::here(format!("{name:?}")),
+                Spanned::here(details.short.to_string()),
+                Spanned::here(details.about.to_string()),
             ]
         }))
-        .collect::<Vec<Vec<String>>>();
+        .collect::<Vec<Vec<Spanned<String>>>>();
         let table = util::format_table(&rows);
         let new_content = re::VALID_TEAM_ASKS.replace_all(&chapter.content, table);
         chapter.content = new_content.to_string();

--- a/crates/rust-project-goals-cli/Cargo.toml
+++ b/crates/rust-project-goals-cli/Cargo.toml
@@ -16,3 +16,4 @@ clap = { version = "4.5.23", features = ["derive"] }
 rust-project-goals-json = { version = "0.1.0", path = "../rust-project-goals-json" }
 handlebars = { version = "6.2.0", features = ["dir_source"] }
 comrak = "0.31.0"
+spanned = "0.4.0"

--- a/crates/rust-project-goals-cli/src/rfc.rs
+++ b/crates/rust-project-goals-cli/src/rfc.rs
@@ -487,7 +487,7 @@ fn task_items(goal_plan: &GoalPlan) -> anyhow::Result<Vec<String>> {
     let mut tasks = vec![];
 
     if let Some(title) = &goal_plan.subgoal {
-        tasks.push(format!("### {title}"));
+        tasks.push(format!("### {}", **title));
     }
 
     for plan_item in &goal_plan.plan_items {

--- a/crates/rust-project-goals-cli/src/updates.rs
+++ b/crates/rust-project-goals-cli/src/updates.rs
@@ -5,6 +5,7 @@ use rust_project_goals::markwaydown;
 use rust_project_goals::re::{HELP_WANTED, TLDR};
 use rust_project_goals::util::comma;
 use rust_project_goals_json::GithubIssueState;
+use spanned::{Span, Spanned};
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -229,7 +230,11 @@ fn help_wanted(
 }
 
 fn why_this_goal(issue_id: &IssueId, issue: &ExistingGithubIssue) -> anyhow::Result<String> {
-    let sections = markwaydown::parse_text(issue_id.url(), &issue.body)?;
+    let span = Span {
+        file: issue_id.url().into(),
+        bytes: 0..0,
+    };
+    let sections = markwaydown::parse_text(Spanned::new(&issue.body, span))?;
     for section in sections {
         if section.title == "Why this goal?" {
             return Ok(section.text.trim().to_string());

--- a/crates/rust-project-goals/Cargo.toml
+++ b/crates/rust-project-goals/Cargo.toml
@@ -16,3 +16,4 @@ rust_team_data = { git = "https://github.com/rust-lang/team" }
 rust-project-goals-json = { version = "0.1.0", path = "../rust-project-goals-json" }
 toml = "0.8.19"
 indexmap = "2.7.1"
+spanned = "0.4.0"

--- a/crates/rust-project-goals/src/format_team_ask.rs
+++ b/crates/rust-project-goals/src/format_team_ask.rs
@@ -3,6 +3,8 @@ use std::{
     path::PathBuf,
 };
 
+use spanned::Spanned;
+
 use crate::{
     config::Configuration,
     goal::TeamAsk,
@@ -117,19 +119,20 @@ pub fn format_team_asks(asks_of_any_team: &[&TeamAsk]) -> anyhow::Result<String>
 
         // Create the table itself.
         let table = {
-            let headings = std::iter::once("Goal".to_string())
+            let headings = std::iter::once(Spanned::here("Goal".to_string()))
                 .chain(ask_headings.iter().map(|&ask_kind| {
-                    format!(
+                    Spanned::here(format!(
                         "[{team_ask_short}][valid_team_asks]", // HACK: This should not be hardcoded in the code.
                         team_ask_short = config.team_asks[ask_kind].short,
-                    )
+                    ))
                 })) // e.g. "discussion and moral support"
-                .collect::<Vec<String>>();
+                .collect::<Vec<Spanned<String>>>();
 
             let rows = goal_rows.into_iter().map(|(goal_data, goal_columns)| {
                 std::iter::once(goal_data.goal_title())
                     .chain(goal_columns)
-                    .collect::<Vec<String>>()
+                    .map(Spanned::here)
+                    .collect::<Vec<Spanned<String>>>()
             });
 
             std::iter::once(headings).chain(rows).collect::<Vec<_>>()

--- a/crates/rust-project-goals/src/markwaydown.rs
+++ b/crates/rust-project-goals/src/markwaydown.rs
@@ -163,8 +163,10 @@ fn categorize_line(line: &str) -> CategorizeLine {
     if line.starts_with('#') {
         let level = line.chars().take_while(|&ch| ch == '#').count();
         CategorizeLine::Title(level, line.trim_start_matches('#').trim().to_string())
-    } else if line.starts_with('|') && line.ends_with('|') {
-        let line = &line[1..line.len() - 1];
+    } else if let Some(line) = line
+        .strip_prefix('|')
+        .and_then(|line| line.strip_suffix('|'))
+    {
         let columns = line.split('|').map(|s| s.trim());
         if columns.clone().all(|s| s.chars().all(|c| c == '-')) {
             CategorizeLine::TableDashRow(columns.count())

--- a/crates/rust-project-goals/src/util.rs
+++ b/crates/rust-project-goals/src/util.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use spanned::Spanned;
 use walkdir::WalkDir;
 
 pub const ARROW: &str = "↳";
@@ -11,7 +12,7 @@ pub const ARROW: &str = "↳";
 /// Formats a table as markdown. The input should be a series of rows
 /// where each row has the same number of columns.
 /// The first row is the headers.
-pub fn format_table(rows: &[Vec<String>]) -> String {
+pub fn format_table(rows: &[Vec<Spanned<String>>]) -> String {
     let mut output = String::new();
 
     let Some((header_row, data_rows)) = rows.split_first() else {
@@ -31,7 +32,13 @@ pub fn format_table(rows: &[Vec<String>]) -> String {
         for (text, col) in columns.iter().zip(0..) {
             output.push('|');
 
-            write!(output, " {text:<width$} ", text = text, width = widths[col]).unwrap();
+            write!(
+                output,
+                " {text:<width$} ",
+                text = **text,
+                width = widths[col]
+            )
+            .unwrap();
         }
 
         output.push('|');


### PR DESCRIPTION
Instead of just tracking line numbers manually, this makes sure that everything preserves spans.

This is done by replicating most of the `str` API on `Spanned<&str>`, so that you can just use `trim`, `to_string`, `chars`... and keep span information at all times. I was not able to measure a performance impact on `just check`.

More can be done here, but I wanted to get a vibeck first before putting in more work.

Many situations already produce errors like

> point of contact must be a single github username (found src/2025h2/TEMPLATE.md:16:22: *must be a single Github username like @ghost*)

where before they did not have file, line and col information