### PR TITLE
tmp: enable backtraces on CI to debug failure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,3 +19,7 @@ jobs:
     - uses: extractions/setup-just@v2
     - name: Build and check
       run: just check
+    - name: tmp just buld
+      run: just build
+      env:
+          RUST_BACKTRACE: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,13 @@ jobs:
     - uses: extractions/setup-just@v2
     - name: Build and check
       run: just check
-    - name: tmp just buld
+    - name: Install mdBook
+      run: |
+        curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
+        rustup update
+        cargo install --version 0.4.40 mdbook
+    - name: tmp just build
       run: just build
       env:
           RUST_BACKTRACE: 1
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -49,6 +49,7 @@ jobs:
         run: just build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUST_BACKTRACE: 1
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/crates/mdbook-goals/src/main.rs
+++ b/crates/mdbook-goals/src/main.rs
@@ -24,14 +24,18 @@ fn main() -> anyhow::Result<()> {
     let opt = Opt::parse();
 
     let Some(cmd) = &opt.cmd else {
+        eprintln!("main - no cmd");
         return handle_preprocessing(&GoalPreprocessor);
     };
 
     match cmd {
         Command::Supports { renderer } => {
+            eprintln!("main - cmd, supports: {renderer}");
             handle_supports(&GoalPreprocessor, renderer)?;
         }
     }
+
+    eprintln!("main - cmd, done");
 
     Ok(())
 }

--- a/crates/mdbook-goals/src/mdbook_preprocessor.rs
+++ b/crates/mdbook-goals/src/mdbook_preprocessor.rs
@@ -31,10 +31,14 @@ impl Preprocessor for GoalPreprocessor {
     }
 
     fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> anyhow::Result<Book> {
+        eprintln!("running goal preprocessor");
         let mut this = GoalPreprocessorWithContext::new(ctx)?;
+        eprintln!("processing book items");
         for section in &mut book.sections {
+            eprintln!("book item: {:?}", section);
             this.process_book_item(section)?;
         }
+        eprintln!("book items done");
         Ok(book)
     }
 }

--- a/crates/rust-project-goals/src/gh/issues.rs
+++ b/crates/rust-project-goals/src/gh/issues.rs
@@ -153,6 +153,14 @@ pub fn list_issues(
         .output()
         .with_context(|| format!("running github cli tool `gh`"))?;
 
+    if !output.status.success() {
+        anyhow::bail!(
+            "`gh` cli tool failed with\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
     let existing_issues: Vec<ExistingGithubIssueJson> = serde_json::from_slice(&output.stdout)?;
 
     Ok(existing_issues


### PR DESCRIPTION
CI is failing for some reason https://github.com/rust-lang/rust-project-goals/actions/runs/15820213687/job/44611492185 and I can't reproduce the issue locally.