### PR TITLE
Propose 2025h2 goal for MIR move elimination optimization

### DIFF
--- a/src/2025h2/mir-move-elimination.md
+++ b/src/2025h2/mir-move-elimination.md
@@ -34,7 +34,7 @@ fn example1() {
     let a = Foo([0; 100]);
     observe(&a);
     let b = a;
-    observe(&bar);
+    observe(&b);
 }
 
 fn example2() {


### PR DESCRIPTION
This goal intends to add a MIR optimization which eliminates moves (`memcpy`) where possible.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2025h2/mir-move-elimination.md)