### PR TITLE
Improve duplicate table errors

### DIFF
--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -537,10 +537,20 @@ fn goal_plan(
                 plan_items,
             }))
         }
-        _ => anyhow::bail!(
-            "multiple goal tables found in section `{}`",
-            section.title.render()
-        ),
+        thats_too_many => {
+            let mut table_error = Vec::new();
+            for (idx, table) in section.tables.iter().enumerate() {
+                let header: Vec<_> = table.header.iter().map(|h| h.to_string()).collect();
+                table_error.push(format!("{}: {:?}", idx + 1, header.join(", ")));
+            }
+
+            anyhow::bail!(
+                "markdown parsing unexpectedly encountered multiple ({}) goal tables in section `{}`:\n{}",
+                thats_too_many,
+                section.title.render(),
+                table_error.join("\n"),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This might have saved me some time when looking for the CI failure in https://github.com/rust-lang/rust-project-goals/pull/331 where a stray space broke the markdown parser into thinking there were multiple tables there but it was unclear as to why.

Before 
```
Error: loading goal from `src/2025h2/scalable-vectors.md`

Caused by:
    multiple goal tables found in section `src/2025h2/scalable-vectors.md:143:4: Ownership and team asks`
```

After 
```
Error: loading goal from `src/2025h2/scalable-vectors.md`

Caused by:
    markdown parsing unexpectedly encountered multiple (2) goal tables in section `src/2025h2/scalable-vectors.md:143:4: Ownership and team asks`:
    1: "Task, Owner(s) or team(s), Notes"
    2: "Implementation, @davidtwco, Part II of Sized Hierarchy implementation"
```

<sub>ngl the `Spanned<String>`s are not IDE-friendly / intuitive to work with<sub>