### PR TITLE
Fix incorrect asks in template

### DIFF
--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -61,7 +61,7 @@
 >
 > *For most goals, a single table will suffice, but you can also add subsections with `###`. We give several example subsections below that also demonstrate the most common kinds of goals. Remember that the items in the table only corresponds to what you plan to do over the next 6 months.*
 >
-> *For items done by a contributor, list the contributor, or ![Heap wanted][] if you don't yet know who will do it. The owner is ideally identified as a github username like `@ghost`.*
+> *For items done by a contributor, list the contributor, or ![Help wanted][] if you don't yet know who will do it. The owner is ideally identified as a github username like `@ghost`.*
 >
 > *For items asked of teams, list ![Team][] and the name of the team, e.g. `![Team][] [compiler]` or `![Team][] [compiler], [lang]` (note the trailing `[]` in `![Team][]`, that is needed for markdown to parse correctly). For team asks, the "task" must be one of the tasks defined in [rust-project-goals.toml](../rust-project-goals.toml) or `cargo rpg check` will error.*
 


### PR DESCRIPTION
People are copying these wholesale eg in https://github.com/rust-lang/rust-project-goals/pull/331, which obviously breaks CI because they're different from https://github.com/rust-lang/rust-project-goals/blob/main/rust-project-goals.toml. 

I'm not sure what the correct terms are between the two in some cases, but they should be consistent for now so that CI works i guess.

also: a fun typo that people copy as well. 

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/TEMPLATE.md)