### PR TITLE
field projections: fix url encoding

### DIFF
--- a/src/2025h2/field-projections.md
+++ b/src/2025h2/field-projections.md
@@ -74,7 +74,7 @@ that improves upon it.
 
 For historical context, there also is the [Field Projections RFC v1].
 
-[newer proposal]: https://hackmd.io/@BennoLossin/HkMBy6Hzlx
+[newer proposal]: https://hackmd.io/%40BennoLossin/HkMBy6Hzlx
 [Field Projections RFC v1]: https://github.com/rust-lang/rfcs/pull/3318
 [Field Projections RFC v2]: https://github.com/rust-lang/rfcs/pull/3735
 


### PR DESCRIPTION
The `@BennoLossin` in the hackmd url gets interpreted as a github username and thus replaced by the url, which breaks the markdown.

Thus use `%40` which encodes `@` instead.

Sorry about the extra work, tested this locally first and it seems to work.

[Rendered](https://github.com/BennoLossin/rust-project-goals/blob/field-projection-2025h2/src/2025h2/field-projections.md)