### PR TITLE
Update goals to reference lang-docs

### DIFF
--- a/rust-project-goals.toml
+++ b/rust-project-goals.toml
@@ -17,7 +17,7 @@
 "Org decision" = { short="Org", about="reach a decision on an organizational or policy matter" }
 "MCP decision" = { short="MCP", about="accept a [Major Change Proposal](https://forge.rust-lang.org/compiler/mcp.html)" }
 "ACP decision" = { short="ACP", about="accept an [API Change Proposal](https://std-dev-guide.rust-lang.org/development/feature-lifecycle.html)" }
-"Finalize specification text" = { short="Spec text", about="assign a spec team liaison to finalize edits to Rust reference/specification" }
+"Review/revise Reference PR" = { short="Reference text", about="assign a lang-docs team liaison to finalize edits to Rust Reference" }
 "Stabilization decision" = { short="Stabilize.", about="reach a decision on a stabilization proposal" }
 "Policy decision" = { short="Policy", about="make a decision related to team policy" }
 "FCP decision(s)" = { short="FCP", about="make formal decision(s) that require 'checkboxes' and a FCP (Final Comment Period)" }

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -100,18 +100,18 @@ This section defines the specific work items that are planned and who is expecte
 
 ### Return type notation
 
-| Task                           | Owner(s) or team(s)                                | Notes         |
-|--------------------------------|----------------------------------------------------|---------------|
-| Initial implementation         | @compiler-errors                                   | ![Complete][] |
-| Author RFC                     | @nikomatsakis                                      | ![Complete][] |
-| RFC decision                   | ![Team][] [lang]                                   | ![Complete][] |
-| Finished implementation        | @compiler-errors                                   | ![Complete][] |
-| Lang-team champion             | ![Team][] [lang]                                   | @nikomatsakis |
-| Standard reviews               | ![Team][] [types], [compiler]                      |               |
-| Author stabilization report    | @compiler-errors                                   |               |
-| Author specification 1st draft | TBD (@compiler-errors, @tmandry, or @nikomatsakis) |               |
-| Finalize specification text    | ![Team][] [spec]                                   | @nikomatsakis |
-| Stabilization decision         | ![Team][] [lang], [types]                          |               |
+| Task                        | Owner(s) or team(s)                                | Notes         |
+|-----------------------------|----------------------------------------------------|---------------|
+| Initial implementation      | @compiler-errors                                   | ![Complete][] |
+| Author RFC                  | @nikomatsakis                                      | ![Complete][] |
+| RFC decision                | ![Team][] [lang]                                   | ![Complete][] |
+| Finished implementation     | @compiler-errors                                   | ![Complete][] |
+| Lang-team champion          | ![Team][] [lang]                                   | @nikomatsakis |
+| Standard reviews            | ![Team][] [types], [compiler]                      |               |
+| Author stabilization report | @compiler-errors                                   |               |
+| Author Reference PR         | TBD (@compiler-errors, @tmandry, or @nikomatsakis) |               |
+| Review/revise Reference PR  | ![Team][] [lang-docs]                              | @nikomatsakis |
+| Stabilization decision      | ![Team][] [lang], [types]                          |               |
 
 ### Unsafe binders
 

--- a/src/2025h1/cargo-script.md
+++ b/src/2025h1/cargo-script.md
@@ -75,14 +75,14 @@ Tracking issue [#136889](https://github.com/rust-lang/rust/issues/136889):
 
 ### Stabilize language feature `frontmatter`
 
-| Task                           | Owner(s) or team(s)                | Notes |
-|--------------------------------|------------------------------------|-------|
-| Author specification 1st draft | @epage |       |
-| Finalize specification text    | ![Team][] [spec]                   |  @ehuss |
-| Lang-team champion             | ![Team][] [lang]                   | @joshtriplett       |
-| Author stabilization report    | @epage |       |
-| Author stabilization PR        | @epage |       |
-| Stabilization decision         | ![Team][] [lang]                   |       |
+| Task                        | Owner(s) or team(s)   | Notes         |
+|-----------------------------|-----------------------|---------------|
+| Author Reference PR         | @epage                |               |
+| Review/revise Reference PR  | ![Team][] [lang-docs] | @ehuss        |
+| Lang-team champion          | ![Team][] [lang]      | @joshtriplett |
+| Author stabilization report | @epage                |               |
+| Author stabilization PR     | @epage                |               |
+| Stabilization decision      | ![Team][] [lang]      |               |
 
 ### Definitions
 

--- a/src/2025h1/restrictions.md
+++ b/src/2025h1/restrictions.md
@@ -43,16 +43,16 @@ high level, but are not the focus of this project goal.
 
 **Owner:** @jhpratt
 
-| Task                                    | Owner(s) or team(s)  | Notes                                      |
-|-----------------------------------------|----------------------|--------------------------------------------|
-| Discussion and moral support            | ![Team][] [lang]     |                                            |
-| Implementation                          | @jhpratt             | [old PR][pr] is plausibly workable         |
-| Standard reviews                        | ![Team][] [compiler] |                                            |
-| Author stabilization report             | @jhpratt             |                                            |
-| Author specification 1st draft          | @jhpratt             |                                            |
-| Finalize specification text             | ![Team][] [spec]     | @joelmarcey                               |
-| Stabilization decision                  | ![Team][] [lang]     |                                            |
-| Inside Rust blog post inviting feedback | @jhpratt             | feedback on syntax if no team consensus    |
+| Task                                    | Owner(s) or team(s)   | Notes                                   |
+|-----------------------------------------|-----------------------|-----------------------------------------|
+| Discussion and moral support            | ![Team][] [lang]      |                                         |
+| Implementation                          | @jhpratt              | [old PR][pr] is plausibly workable      |
+| Standard reviews                        | ![Team][] [compiler]  |                                         |
+| Author stabilization report             | @jhpratt              |                                         |
+| Author Reference PR                     | @jhpratt              |                                         |
+| Review/revise Reference PR              | ![Team][] [lang-docs] | @joelmarcey                             |
+| Stabilization decision                  | ![Team][] [lang]      |                                         |
+| Inside Rust blog post inviting feedback | @jhpratt              | feedback on syntax if no team consensus |
 
 ### Definitions
 

--- a/src/2025h2/Rust-for-Linux-language.md
+++ b/src/2025h2/Rust-for-Linux-language.md
@@ -73,15 +73,15 @@ Which features get finished and stabilized depends on bandwidth and other constr
 
 ### Finish and stabilize `arbitrary_self_types` and `derive_coerce_pointee`
 
-| Task                           | Owner(s) or team(s) | Notes |
-|--------------------------------|---------------------|-------|
-| Discussion and moral support   | ![Team][] [lang]    |       |
-| Finalize remaining work        | @dingxiangfei2009   |       |
-| Author specification 1st draft | @dingxiangfei2009   |       |
-| Finalize specification text    | ![Team][] [spec]    |       |
-| Lang-team champion             | ![Team][] [lang]    |       |
-| Author stabilization report    | @dingxiangfei2009   |       |
-| Author stabilization PR        | @dingxiangfei2009   |       |
-| Stabilization decision         | ![Team][] [lang]    |       |
+| Task                         | Owner(s) or team(s)   | Notes |
+|------------------------------|-----------------------|-------|
+| Discussion and moral support | ![Team][] [lang]      |       |
+| Finalize remaining work      | @dingxiangfei2009     |       |
+| Author Reference PR          | @dingxiangfei2009     |       |
+| Review/revise Reference PR   | ![Team][] [lang-docs] |       |
+| Lang-team champion           | ![Team][] [lang]      |       |
+| Author stabilization report  | @dingxiangfei2009     |       |
+| Author stabilization PR      | @dingxiangfei2009     |       |
+| Stabilization decision       | ![Team][] [lang]      |       |
 
 ## Frequently asked questions

--- a/src/2025h2/cargo-script.md
+++ b/src/2025h2/cargo-script.md
@@ -76,14 +76,14 @@ Tracking issue [#136889](https://github.com/rust-lang/rust/issues/136889):
 
 ### Stabilize language feature `frontmatter`
 
-| Task                           | Owner(s) or team(s)                | Notes |
-|--------------------------------|------------------------------------|-------|
-| Author specification 1st draft | @epage |       |
-| Finalize specification text    | ![Team][] [spec]                   |  @ehuss |
-| Lang-team champion             | ![Team][] [lang]                   | @joshtriplett       |
-| Author stabilization report    | @epage |       |
-| Author stabilization PR        | @epage |       |
-| Stabilization decision         | ![Team][] [lang]                   |       |
+| Task                        | Owner(s) or team(s)   | Notes         |
+|-----------------------------|-----------------------|---------------|
+| Author Reference PR         | @epage                |               |
+| Review/revise Reference PR  | ![Team][] [lang-docs] | @ehuss        |
+| Lang-team champion          | ![Team][] [lang]      | @joshtriplett |
+| Author stabilization report | @epage                |               |
+| Author stabilization PR     | @epage                |               |
+| Stabilization decision      | ![Team][] [lang]      |               |
 
 ### Definitions
 

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -98,18 +98,18 @@
 
 > *If the feature has been RFC'd and implemented and experiences are positive, [stabilization](https://rustc-dev-guide.rust-lang.org/stabilization_guide.html) may be the right next step. In this case, you will need to author a first draft of text for the Rust reference and make a Team Ask to request someone from the the spec team to adapt that text for final inclusion. You will also need to author a stabilization report.
 
-| Task                           | Owner(s) or team(s)                | Notes |
-|--------------------------------|------------------------------------|-------|
-| Author specification 1st draft | *Goal point of contact, typically* |       |
-| Finalize specification text    | ![Team][] [spec]                   |       |
-| Lang-team champion             | ![Team][] [lang]                   |       |
-| Author stabilization report    | *Goal point of contact, typically* |       |
-| Author stabilization PR        | *Goal point of contact, typically* |       |
-| Stabilization decision         | ![Team][] [lang]                   |       |
+| Task                        | Owner(s) or team(s)                | Notes |
+|-----------------------------|------------------------------------|-------|
+| Author Reference PR         | *Goal point of contact, typically* |       |
+| Review/revise Reference PR  | ![Team][] [lang-docs]              |       |
+| Lang-team champion          | ![Team][] [lang]                   |       |
+| Author stabilization report | *Goal point of contact, typically* |       |
+| Author stabilization PR     | *Goal point of contact, typically* |       |
+| Stabilization decision      | ![Team][] [lang]                   |       |
 
 ### Stabilize library feature
 
-> *Standard library features follow the [libs-api stabilization process](https://rustc-dev-guide.rust-lang.org/stability.html#stabilizing-a-library-feature). 
+> *Standard library features follow the [libs-api stabilization process](https://rustc-dev-guide.rust-lang.org/stability.html#stabilizing-a-library-feature).
 
 | Task                           | Owner(s) or team(s)                | Notes |
 |--------------------------------|------------------------------------|-------|


### PR DESCRIPTION
In the context of a project goal reserving the bandwidth of a team, the work of reviewing and revising proposed Reference text at this time falls more on the T-lang-docs side rather than on the T-spec side.  So let's update the relevant project goals and the template accordingly.

cc @rust-lang/lang-docs

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2025h1/async.md)