### PR TITLE
simplify templates

### DIFF
--- a/crates/mdbook-goals/src/mdbook_preprocessor.rs
+++ b/crates/mdbook-goals/src/mdbook_preprocessor.rs
@@ -181,7 +181,7 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         }
 
         let Some(chapter_path) = &chapter.path else {
-            anyhow::bail!("found `<!-- #GOALS -->` but chapter has no path")
+            anyhow::bail!("found `(((#GOALS)))` but chapter has no path")
         };
 
         let goals = self.goal_documents(chapter_path)?;
@@ -275,7 +275,7 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         let range = m.range();
 
         let Some(path) = &chapter.path else {
-            anyhow::bail!("found `<!-- TEAM ASKS -->` but chapter has no path")
+            anyhow::bail!("found `(((TEAM ASKS)))` but chapter has no path")
         };
 
         let goals = self.goal_documents(path)?;

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -9,7 +9,7 @@ use spanned::{Error, Result, Spanned};
 use crate::config::{Configuration, TeamAskDetails};
 use crate::gh::issue_id::{IssueId, Repository};
 use crate::markwaydown::{self, Section, Table};
-use crate::re::{self, CHAMPION_METADATA, TASK_OWNERS_STR};
+use crate::re::{self, CHAMPION_METADATA};
 use crate::team::{self, TeamName};
 use crate::util::{self, commas, markdown_files};
 
@@ -446,9 +446,8 @@ fn extract_metadata(sections: &[Section]) -> Result<Option<Metadata>> {
         None
     };
 
-    // We no longer require the Teams row to contain a specific placeholder
-    // since we auto-inject team names during preprocessing
-    verify_row(&first_table.rows, "Task owners", TASK_OWNERS_STR)?;
+    // We no longer require the Teams or Task owners rows to contain specific placeholders
+    // since we auto-inject team names and task owners during preprocessing
 
     let mut champions = BTreeMap::default();
     for row in &first_table.rows {
@@ -498,22 +497,7 @@ fn extract_metadata(sections: &[Section]) -> Result<Option<Metadata>> {
     }))
 }
 
-fn verify_row(rows: &[Vec<Spanned<String>>], key: &str, value: &str) -> Result<()> {
-    let Some(row) = rows.iter().find(|row| row[0] == key) else {
-        spanned::bail!(rows[0][0], "metadata table has no `{}` row", key)
-    };
 
-    if row[1] != value {
-        spanned::bail!(
-            row[1],
-            "metadata table has incorrect `{}` row, expected `{}`",
-            key,
-            value
-        )
-    }
-
-    Ok(())
-}
 
 fn extract_summary(sections: &[Section]) -> Result<Option<String>> {
     let Some(ownership_section) = sections.iter().find(|section| section.title == "Summary") else {

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -52,6 +52,9 @@ pub struct Metadata {
 
     /// For each table entry like `[T-lang] champion`, we create an entry in this map
     pub champions: BTreeMap<&'static TeamName, Spanned<String>>,
+
+    /// Flagship category, if this is a flagship goal
+    pub flagship: Option<Spanned<String>>,
 }
 
 pub const TRACKING_ISSUE_ROW: &str = "Tracking issue";
@@ -482,6 +485,13 @@ fn extract_metadata(sections: &[Section]) -> Result<Option<Metadata>> {
         }
     }
 
+    // Parse flagship row if present
+    let flagship = first_table
+        .rows
+        .iter()
+        .find(|row| row[0] == "Flagship")
+        .map(|row| row[1].clone());
+
     Ok(Some(Metadata {
         title: title.to_string(),
         short_title: if let Some(row) = short_title_row {
@@ -494,6 +504,7 @@ fn extract_metadata(sections: &[Section]) -> Result<Option<Metadata>> {
         tracking_issue: issue,
         table: first_table.clone(),
         champions,
+        flagship,
     }))
 }
 
@@ -745,6 +756,11 @@ fn extract_identifiers(s: &str) -> Vec<&str> {
 }
 
 impl Metadata {
+    /// Returns the flagship category if this is a flagship goal
+    pub fn flagship(&self) -> Option<&str> {
+        self.flagship.as_ref().map(|s| s.content.as_str())
+    }
+
     /// Extracts the `@abc` usernames found in the owner listing.
     pub fn owner_usernames(&self) -> Vec<&str> {
         owner_usernames(&self.pocs)

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -9,7 +9,7 @@ use spanned::{Error, Result, Spanned};
 use crate::config::{Configuration, TeamAskDetails};
 use crate::gh::issue_id::{IssueId, Repository};
 use crate::markwaydown::{self, Section, Table};
-use crate::re::{self, CHAMPION_METADATA, TASK_OWNERS_STR, TEAMS_WITH_ASKS_STR};
+use crate::re::{self, CHAMPION_METADATA, TASK_OWNERS_STR};
 use crate::team::{self, TeamName};
 use crate::util::{self, commas, markdown_files};
 
@@ -110,6 +110,11 @@ pub struct TeamAsk {
 pub fn goals_in_dir(directory_path: &Path) -> Result<Vec<GoalDocument>> {
     let mut goal_documents = vec![];
     for (path, link_path) in markdown_files(&directory_path)? {
+        // Skip template files
+        if path.file_name().unwrap() == "TEMPLATE.md" {
+            continue;
+        }
+        
         if let Some(goal_document) = GoalDocument::load(&path, &link_path)? {
             goal_documents.push(goal_document);
         }
@@ -441,7 +446,8 @@ fn extract_metadata(sections: &[Section]) -> Result<Option<Metadata>> {
         None
     };
 
-    verify_row(&first_table.rows, "Teams", TEAMS_WITH_ASKS_STR)?;
+    // We no longer require the Teams row to contain a specific placeholder
+    // since we auto-inject team names during preprocessing
     verify_row(&first_table.rows, "Task owners", TASK_OWNERS_STR)?;
 
     let mut champions = BTreeMap::default();

--- a/crates/rust-project-goals/src/markwaydown.rs
+++ b/crates/rust-project-goals/src/markwaydown.rs
@@ -162,7 +162,10 @@ fn categorize_line(line: Spanned<&str>) -> CategorizeLine {
         .and_then(|line| line.strip_suffix("|"))
     {
         let columns = line.split('|').map(|s| s.trim());
-        if columns.clone().all(|s| s.chars().all(|c| *c == '-')) {
+        if columns
+            .clone()
+            .all(|s| s.chars().all(|c| *c == '-' || *c == ':'))
+        {
             CategorizeLine::TableDashRow(columns.map(|s| s.map(drop)).collect())
         } else {
             CategorizeLine::TableRow(columns.map(|s| s.to_string()).collect())

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -2,28 +2,28 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {
-    pub static ref TEAM_ASKS: Regex = Regex::new(r"<!-- TEAM ASKS -->").unwrap();
+    pub static ref TEAM_ASKS: Regex = Regex::new(r"\(\(\(TEAM ASKS\)\)\)").unwrap();
 }
 
 // List of all goals, flagship or otherwise
 lazy_static! {
-    pub static ref GOAL_LIST: Regex = Regex::new(r"<!-- GOALS -->").unwrap();
+    pub static ref GOAL_LIST: Regex = Regex::new(r"\(\(\(GOALS\)\)\)").unwrap();
 }
 
 // List of flagship goals (accepted or pending)
 lazy_static! {
-    pub static ref FLAGSHIP_GOAL_LIST: Regex = Regex::new(r"<!-- FLAGSHIP GOALS -->").unwrap();
+    pub static ref FLAGSHIP_GOAL_LIST: Regex = Regex::new(r"\(\(\(FLAGSHIP GOALS\)\)\)").unwrap();
 }
 
 // List of non-flagship goals (accepted or pending)
 lazy_static! {
-    pub static ref OTHER_GOAL_LIST: Regex = Regex::new(r"<!-- OTHER GOALS -->").unwrap();
+    pub static ref OTHER_GOAL_LIST: Regex = Regex::new(r"\(\(\(OTHER GOALS\)\)\)").unwrap();
 }
 
 // List of not accepted goals
 lazy_static! {
     pub static ref GOAL_NOT_ACCEPTED_LIST: Regex =
-        Regex::new(r"<!-- GOALS NOT ACCEPTED -->").unwrap();
+        Regex::new(r"\(\(\(GOALS NOT ACCEPTED\)\)\)").unwrap();
 }
 
 
@@ -31,11 +31,11 @@ lazy_static! {
 
 
 lazy_static! {
-    pub static ref GOAL_COUNT: Regex = Regex::new(r"<!-- #GOALS -->").unwrap();
+    pub static ref GOAL_COUNT: Regex = Regex::new(r"\(\(\(#GOALS\)\)\)").unwrap();
 }
 
 lazy_static! {
-    pub static ref VALID_TEAM_ASKS: Regex = Regex::new(r"<!-- VALID TEAM ASKS -->").unwrap();
+    pub static ref VALID_TEAM_ASKS: Regex = Regex::new(r"\(\(\(VALID TEAM ASKS\)\)\)").unwrap();
 }
 
 lazy_static! {

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -15,6 +15,11 @@ lazy_static! {
     pub static ref FLAGSHIP_GOAL_LIST: Regex = Regex::new(r"\(\(\(FLAGSHIP GOALS\)\)\)").unwrap();
 }
 
+// List of flagship goals filtered by category (accepted or pending)
+lazy_static! {
+    pub static ref FLAGSHIP_GOAL_LIST_FILTERED: Regex = Regex::new(r"\(\(\(FLAGSHIP GOALS:\s*([^)]+?)\s*\)\)\)").unwrap();
+}
+
 // List of non-flagship goals (accepted or pending)
 lazy_static! {
     pub static ref OTHER_GOAL_LIST: Regex = Regex::new(r"\(\(\(OTHER GOALS\)\)\)").unwrap();

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -17,7 +17,8 @@ lazy_static! {
 
 // List of flagship goals filtered by category (accepted or pending)
 lazy_static! {
-    pub static ref FLAGSHIP_GOAL_LIST_FILTERED: Regex = Regex::new(r"\(\(\(FLAGSHIP GOALS:\s*([^)]+?)\s*\)\)\)").unwrap();
+    pub static ref FLAGSHIP_GOAL_LIST_FILTERED: Regex =
+        Regex::new(r"\(\(\(FLAGSHIP GOALS:\s*(.+?)\s*\)\)\)").unwrap();
 }
 
 // List of non-flagship goals (accepted or pending)
@@ -31,12 +32,12 @@ lazy_static! {
         Regex::new(r"\(\(\(GOALS NOT ACCEPTED\)\)\)").unwrap();
 }
 
-
-
-
-
 lazy_static! {
     pub static ref GOAL_COUNT: Regex = Regex::new(r"\(\(\(#GOALS\)\)\)").unwrap();
+}
+
+lazy_static! {
+    pub static ref FLAGSHIP_GOAL_COUNT: Regex = Regex::new(r"\(\(\(#FLAGSHIP GOALS\)\)\)").unwrap();
 }
 
 lazy_static! {

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -28,11 +28,7 @@ lazy_static! {
 
 
 
-// List of task owners for this goal
-pub const TASK_OWNERS_STR: &str = r"<!-- TASK OWNERS -->";
-lazy_static! {
-    pub static ref TASK_OWNERS: Regex = Regex::new(TASK_OWNERS_STR).unwrap();
-}
+
 
 lazy_static! {
     pub static ref GOAL_COUNT: Regex = Regex::new(r"<!-- #GOALS -->").unwrap();

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -26,11 +26,7 @@ lazy_static! {
         Regex::new(r"<!-- GOALS NOT ACCEPTED -->").unwrap();
 }
 
-// List of teams with asks for this goal
-pub const TEAMS_WITH_ASKS_STR: &str = r"<!-- TEAMS WITH ASKS -->";
-lazy_static! {
-    pub static ref TEAMS_WITH_ASKS: Regex = Regex::new(TEAMS_WITH_ASKS_STR).unwrap();
-}
+
 
 // List of task owners for this goal
 pub const TASK_OWNERS_STR: &str = r"<!-- TASK OWNERS -->";

--- a/migrate_flagship.py
+++ b/migrate_flagship.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Migration script to convert flagship goals from the old format to the new format.
+
+Old format: | Status | Flagship |
+New format: | Status | Accepted | + | Flagship | Yes |
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+def migrate_file(file_path):
+    """Migrate a single goal file from old to new flagship format."""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    original_content = content
+    
+    # Look for metadata table with Status | Flagship
+    # We need to be careful to only match within the metadata table
+    lines = content.split('\n')
+    
+    # Find the metadata table (starts after a line with just "| Metadata" and ends at the first empty line or non-table line)
+    in_metadata_table = False
+    metadata_start = None
+    metadata_end = None
+    
+    for i, line in enumerate(lines):
+        if '| Metadata' in line and '|' in line:
+            in_metadata_table = True
+            metadata_start = i
+            continue
+        
+        if in_metadata_table:
+            # Check if this line is still part of the table
+            if line.strip() == '' or not line.strip().startswith('|'):
+                metadata_end = i
+                break
+            
+            # Check for Status | Flagship pattern
+            if re.match(r'\s*\|\s*Status\s*\|\s*Flagship\s*\|', line):
+                # Replace Status | Flagship with Status | Accepted
+                lines[i] = re.sub(r'(\|\s*Status\s*\|\s*)Flagship(\s*\|)', r'\1Accepted\2', line)
+                
+                # Find where to insert the Flagship | Yes row
+                # Insert it right after the Status row
+                flagship_row = f"| Flagship         | Yes                                |"
+                lines.insert(i + 1, flagship_row)
+                
+                print(f"Migrated {file_path}")
+                break
+    
+    # Write back if changed
+    new_content = '\n'.join(lines)
+    if new_content != original_content:
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        return True
+    
+    return False
+
+def main():
+    """Main migration function."""
+    if len(sys.argv) > 1:
+        # Specific files provided
+        files_to_migrate = [Path(arg) for arg in sys.argv[1:]]
+    else:
+        # Find all .md files in src/
+        src_dir = Path('src')
+        if not src_dir.exists():
+            print("Error: src/ directory not found. Run this script from the project root.")
+            sys.exit(1)
+        
+        files_to_migrate = list(src_dir.rglob('*.md'))
+    
+    migrated_count = 0
+    
+    for file_path in files_to_migrate:
+        if file_path.is_file():
+            if migrate_file(file_path):
+                migrated_count += 1
+    
+    print(f"Migration complete. {migrated_count} files migrated.")
+
+if __name__ == '__main__':
+    main()

--- a/src/2024h2/ATPIT.md
+++ b/src/2024h2/ATPIT.md
@@ -3,8 +3,6 @@
 | Metadata       |                                    |
 |----------------|------------------------------------|
 | Point of contact | @oli-obk                           |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#103] |
 | Zulip channel  | N/A                                |

--- a/src/2024h2/Contracts-and-invariants.md
+++ b/src/2024h2/Contracts-and-invariants.md
@@ -3,8 +3,6 @@
 | Metadata |                            |
 | -------- | -------------------------- |
 | Point of contact | @pnkfelix                  |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status   | Not accepted               |
 | Zulip channel  | N/A                                |
 
@@ -49,8 +47,6 @@ Third: the Racket language [has demonstrated][findler-felleisen] that when you h
 4. Work with Lang and Libs team on acceptable surface-level syntax for contracts. In particular, we want contracts to be *used* by the Rust standard library. (At the very least, for method pre- and post-conditions; I can readily imagine, however, also attaching contracts to `unsafe { ... }` blocks.)
 
 5. Extend miri to evaluate contract predicates. Add primitives for querying memory model to contract language, to enable contracts that talk about provenance of pointers.
-
-
 ### The "shiny future" we are working towards
 
 My shiny future is that the people "naturally" write Rust crates that can be combined with distinct dynamic-validation and verification tools. Today, if you want to use any verification tool, you usually have to pick one and orient your whole code base around using it. (E.g., the third-party verification tools often have their own (rewrite of a subset of the) Rust standard library, if only so that they can provide the contracts that our standard library is missing.)
@@ -126,8 +122,6 @@ This does not imply that contracts must be useless for arbitrary code. Dynamic c
 Racket development style: add more contracts to the code when debugging (including, but not limited to, contract failures)
 
 A validation mechanism can be bolted-on after the fact.
-
-
 ## Ownership and team asks
 
 **Owner:** pnkfelix
@@ -143,8 +137,6 @@ celinval is also assisting. celinval is part of the Amazon team producing the Ka
 * Libs-impl: We will need libs-impl team engagement to ensure we design a contract language that the standard library implementors are willing to use. To put it simply: If we land support for contracts without uptake within the Rust standard library, then the effort will have failed.
 
 * Lang: We need approval for a lang team experiment to design the contract surface language. However, we do not expect this surface language to be stabilized in 2024, and therefore the language team involvement can be restricted to "whomever is interested in the effort." In addition, it seems likely that at least *some* of the contracts work will dovetail with the [ghost-code initiative](https://github.com/rust-lang/lang-team/issues/161)
-
-
 * WG-formal-methods: We need engagement with the formal-methods community to ensure our contract system is serving their needs.
 
 * Stable-MIR: Contracts and invariants both require evaluation of predicates, and linking those predicates with intermediate states of the Rust abstract machine.
@@ -165,15 +157,11 @@ Rustc has unstable support for embedding dynamic contract-checks into Rust objec
 Some dynamic tool (e.g. miri or valgrind) that can dynamically check contracts whose bodies are *not* embedded into the object code.
 
 Some static verification tool (e.g. Kani) leverages contracts shipped with Rust standard library.
-
-
 ### Milestones
 
 Unstable syntactic support for contracts in Rust programs (at API boundaries at bare minimum, but hopefully also at other natural points in a code base.)
 
 Support for extracting contracts for a given item from an rlib.
-
-
 ## Frequently asked questions
 
 ### Q: How do contracts help static verification tools?
@@ -190,8 +178,6 @@ See next question for an answer to this.
 ### Q: How are you planning to dynamically check arbitrary contracts?
 
 A dynamic check of the construct `forall(|x:T| { … })` sounds problematic for most T of interest
-
-
 pnkfelix's expectation here is that we would *not* actually expect to support `forall(|x:T| ...)` in a dynamic context, not in the general case of arbitrary `T`.
 
 pnkfelix's current favorite solution for cracking this nut: a new form, `forall!(|x:T| suchas: [x_expr1, x_expr2, …] { … })`,
@@ -216,7 +202,3 @@ pnkfelix does not know the complete answer here.
 Some dynamic checks would benefit from access to memory model internals. 
 
 But in general, checking the correctness of an unsafe abstraction needs type-specific ghost state (to model permissions, etc). We are leaving this for future work, it may or may not get resolved this year.
-
-
-
-

--- a/src/2024h2/Patterns-of-empty-types.md
+++ b/src/2024h2/Patterns-of-empty-types.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @Nadrieril                         |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#115] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Introduce an RFC for never patterns or other solutions for patterns involving uninhabited types.
@@ -95,8 +91,6 @@ already for several months.
     * The feature may require one design meeting.
 * Implementation work is 80% done, which leaves about 80% more to do. This will require reviews from
   the compiler team, but not more than the ordinary.
-
-
 | Task                         | Owner(s) or team(s)  | Notes |
 | ---------------------------- | -------------------- | ----- |
 | Author RFC                   | @Nadrieril           |       |

--- a/src/2024h2/Polonius.md
+++ b/src/2024h2/Polonius.md
@@ -3,8 +3,6 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @lqd                               |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#118] |
 | Zulip channel  | [#t-types/polonius][channel]       |

--- a/src/2024h2/Project-goal-slate.md
+++ b/src/2024h2/Project-goal-slate.md
@@ -3,15 +3,11 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @nikomatsakis                      |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#102] |
 | Zulip channel  | [#project-goals][channel]               |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/435869-project-goals
-
-
 *Extracted from [RFC 3614](https://github.com/rust-lang/rfcs/blob/master/text/3614-project-goals.md)*
 
 ## Summary

--- a/src/2024h2/README.md
+++ b/src/2024h2/README.md
@@ -1,6 +1,6 @@
 # Rust project goals for 2024H2
 
-> ![Status: Accepted](https://img.shields.io/badge/Status-Accepted-green) [RFC #3672] has been **accepted**, establishing [<!-- #GOALS --> total Rust project goals for 2024H2](./goals.md).
+> ![Status: Accepted](https://img.shields.io/badge/Status-Accepted-green) [RFC #3672] has been **accepted**, establishing [(((#GOALS))) total Rust project goals for 2024H2](./goals.md).
 
 ## Want to learn more?
 

--- a/src/2024h2/Relaxing-the-Orphan-Rule.md
+++ b/src/2024h2/Relaxing-the-Orphan-Rule.md
@@ -3,8 +3,6 @@
 | Metadata |                     |
 | -------- | ------------------- |
 | Point of contact | @nikomatsakis    |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status   | Not accepted        |
 | Zulip channel  | N/A                                |
 

--- a/src/2024h2/Rust-2024-Edition.md
+++ b/src/2024h2/Rust-2024-Edition.md
@@ -3,15 +3,11 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @traviscross                       |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Flagship                           |
 | Tracking issue | [rust-lang/rust-project-goals#117] |
 | Zulip channel  | [#edition][channel]                |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/268952-edition
-
-
 ## Summary
 
 Feature complete status for Rust 2024, with final release to occur in early 2025.

--- a/src/2024h2/Rust-2024-Edition.md
+++ b/src/2024h2/Rust-2024-Edition.md
@@ -3,7 +3,8 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @traviscross                       |
-| Status         | Flagship                           |
+| Status         | Accepted                           |
+| Flagship         | Yes                                |
 | Tracking issue | [rust-lang/rust-project-goals#117] |
 | Zulip channel  | [#edition][channel]                |
 

--- a/src/2024h2/Rust-for-SciComp.md
+++ b/src/2024h2/Rust-for-SciComp.md
@@ -3,14 +3,10 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @ZuseZ4                            |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#109] |
 | Other tracking issues | [rust-lang/rust#124509], [rust-lang/rust#124509] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Expose experimental LLVM features for automatic differentiation and GPU offloading.

--- a/src/2024h2/Seamless-C-Support.md
+++ b/src/2024h2/Seamless-C-Support.md
@@ -3,8 +3,6 @@
 | Metadata | |
 | --- | --- |
 | Point of contact | @joshtriplett |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status | Not accepted |
 | Zulip channel  | N/A                                |
 

--- a/src/2024h2/a-mir-formality.md
+++ b/src/2024h2/a-mir-formality.md
@@ -3,8 +3,6 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @nikomatsakis                      |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#122] |
 | Zulip channel  | [#t-types/formality][channel]      |

--- a/src/2024h2/accepted.md
+++ b/src/2024h2/accepted.md
@@ -4,4 +4,4 @@ This page lists the project goals accepted for 2024h2, with the exception of [fl
 
 Some goals here do not yet have an owner (look for the ![Help wanted][] badge). Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these orphaned goals, reach out to the mentor listed in the goal to discuss.
 
-<!-- GOALS -->
+(((GOALS)))

--- a/src/2024h2/annotate-snippets.md
+++ b/src/2024h2/annotate-snippets.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |------------------|------------------------------------|
 | Point of contact | @Muscraft                          |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#123] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 Switch to annotate-snippets for rendering rustc's output, with no loss of functionality or visual regressions.
@@ -36,12 +32,8 @@ The outputs of rustc and cargo are fully using annotate-snippets, with no regres
 ## Design axioms
 
 *This section is optional, but including [design axioms][da] can help you signal how you intend to balance constraints and tradeoffs (e.g., "prefer ease of use over performance" or vice versa). Teams should review the axioms and make sure they agree. [Read more about design axioms][da].*
-
-
 - **Match rustc's output**: The output of annotate-snipepts should match rustc, modulo reasonable non-significant divergences
 - **Works for Cargo (and other tools)**: annotate-snippets is meant to be used by any project that would like "Rust-style" output, so it should be designed to work with any project, not just rustc.
-
-
 [da]: https://rust-lang.github.io/rust-project-goals/about/design_axioms.html
 
 ## Ownership and team asks

--- a/src/2024h2/async.md
+++ b/src/2024h2/async.md
@@ -4,7 +4,8 @@
 |------------------|------------------------------------|
 | Short title      | Async                              |
 | Point of contact | @tmandry                           |
-| Status           | Flagship                           |
+| Status           | Accepted                           |
+| Flagship         | Yes                                |
 | Tracking issue   | [rust-lang/rust-project-goals#105] |
 | Zulip channel    | [#wg-async][channel]               |
 

--- a/src/2024h2/async.md
+++ b/src/2024h2/async.md
@@ -4,8 +4,6 @@
 |------------------|------------------------------------|
 | Short title      | Async                              |
 | Point of contact | @tmandry                           |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Flagship                           |
 | Tracking issue   | [rust-lang/rust-project-goals#105] |
 | Zulip channel    | [#wg-async][channel]               |
@@ -237,8 +235,6 @@ Here is a detailed list of the work to be done and who is expected to do it. Thi
 | Implementation work |                      | ![Not funded][] (*) |
 | Design meeting      | ![Team][] [lang]     | 2 meetings expected |
 | Standard reviews    | ![Team][] [compiler] |                     |
-
-
 (*) Implementation work on async drop experiments is currently unfunded. We are trying to figure out next steps.
 
 [Approved]: https://img.shields.io/badge/Approved-green

--- a/src/2024h2/cargo-script.md
+++ b/src/2024h2/cargo-script.md
@@ -3,8 +3,6 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @epage                           |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#119] |
 | Zulip channel  | N/A                                |

--- a/src/2024h2/cargo-semver-checks.md
+++ b/src/2024h2/cargo-semver-checks.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @obi1kenobi                        |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#104] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Design and implement `cargo-semver-checks` functionality that lies on the critical path for merging the tool into cargo itself.

--- a/src/2024h2/const-traits.md
+++ b/src/2024h2/const-traits.md
@@ -3,8 +3,6 @@
 | Metadata       |                                             |
 | ---            | ---                                         |
 | Point of contact | @fee1-dead                                |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                                    |
 | Tracking issue | [rust-lang/rust-project-goals#106]          |
 | Zulip channel  | [#t-compiler/project-const-traits][channel] |

--- a/src/2024h2/doc_cfg.md
+++ b/src/2024h2/doc_cfg.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @GuillaumeGomez                    |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#120] |
 | Zulip channel  | N/A                                |
-
-
 @GuillaumeGomez: https://github.com/GuillaumeGomez
 
 ## Motivation
@@ -35,8 +31,6 @@ N/A
 ## Ownership and team asks
 
 **Owner:** @GuillaumeGomez
-
-
 | Task             | Owner(s) or team(s) | Notes |
 | ---------------- | ------------------- | ----- |
 | Implementation   | @GuillaumeGomez     |       |

--- a/src/2024h2/ergonomic-rc.md
+++ b/src/2024h2/ergonomic-rc.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @jkelleyrtp                        |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#107] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Deliver nightly support some solution to reduce the ergonomic pain of working with ref-counted and cheaply cloneable types.

--- a/src/2024h2/ergonomics-initiative.md
+++ b/src/2024h2/ergonomics-initiative.md
@@ -3,8 +3,6 @@
 | Metadata |              |
 | -------- | ------------ |
 | Point of contact | @jkelleyrtp  |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status   | Not accepted |
 | Zulip channel  | N/A                                |
 
@@ -146,8 +144,6 @@ This is a very frequent papercut for both beginner and experienced Rust programm
 As part of the "higher level Rust" effort, we want to reduce the frequency of this papercut, making it easier for developers to model and iterate on their program architecture.
 
 For example, a syntax-free approach to solving this problem might be simply turning on disjoint capture for *private methods only*. Alternatively, we could implement a syntax or attribute that allows developers to explicitly opt in to the partial borrow system. Again, we don't want to necessarily prescribe a solution here, but the best outcome would be a solution that reduces mental overhead with as little new syntax as possible.
-
-
 ### The "shiny future" we are working towards
 
 A "high level Rust" would be a Rust that has a strong focus on iteration speed. Developers would benefit from Rust's performance, safety, and reliability guarantees without the current status quo of long compile times, verbose code, and program architecture limitations.
@@ -286,11 +282,7 @@ let res = Client::new()!
 	.json::<DogApi>()
 	.await!;
 ```
-
-
 A "higher level Rust" would provide similar affordances to prototype code that it provides to production code. All production code was once prototype code. Today's Rust makes it harder to write prototype code than it does production code. This language-level opinion is seemingly unique to Rust and arguably a major factor in why Rust has seen slower adoption in higher level programming paradigms.
-
-
 #### Named and Optional Arguments or Partial Defaults (Contentious)
 
 Beyond `.clone()` and `.unwrap()`, the next biggest polluter for "high level" Rust code tends to be the lack of a way to properly supply optional arguments to various operations. This has received lots of discussion already and we don't want to belabor the point anymore than it already has.
@@ -344,4 +336,3 @@ We don't want to specify any particular solution:
 - Anonymous structs would be useful outside of replacing builders
 
 Generally though, we feel like this is another core problem that needs to be solved for Rust to see more traction in higher-level programming paradigms.
-

--- a/src/2024h2/faster-iterative-builds.md
+++ b/src/2024h2/faster-iterative-builds.md
@@ -3,8 +3,6 @@
 | Metadata         |                             |
 |------------------|-----------------------------|
 | Point of contact | @jkelleyrtp                 |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status           | Not accepted                |
 | Zulip channel  | N/A                                |
 
@@ -40,8 +38,6 @@ There are other longer term projects that would be interesting to pursue but don
 Today, the Rust compiler does not necessarily cache the tokens from procedural macro expansion. On every `cargo check`, and `cargo build`, Rust will run procedural macros to expand code for the compiler. The vast majority of procedural macros in Rust are idempotent: their output tokens are simply a deterministic function of their input tokens. If we assumed a procedural macro was free of side-effects, then we would only need to re-run procedural macros when the input tokens change. This has been shown in prototypes to drastically improve incremental compile times (30% speedup), especially for codebases that employ lots of derives (Debug, Clone, PartialEq, Hash, serde::Serialize).
 
 A solution here could either be manual or automatic: macro authors could opt-in to caching or the compiler could automatically cache macros it knows are side-effect free.
-
-
 #### Faster fresh builds and higher default optimization levels
 
 A "higher level Rust" would be a Rust where a programmer would be able to start a new project, add several large dependencies, and get to work quickly without waiting minutes for a fresh compile. A web developer would be able to jump into a Tokio/Axum heavy project, a game developer into a Bevy/WGPU heavy project, or a data scientist into a Polars project and start working without incurring a 2-5 minute penalty. In today's world, an incoming developer interested in using Rust for their next project immediately runs into a compile wall. In reality, Rust's incremental compile times are rather good, but Rust's perception is invariably shaped by the "new to Rust" experience which is almost always a long upfront compile time.
@@ -51,8 +47,6 @@ Cargo's current compilation model involves downloading and compiling dependencie
 A "higher level Rust" might employ some form of caching - either per-user, per-machine, per-organization, per-library, or otherwise - such that fresh builds are just as fast as incremental builds. If the caching was sufficiently capable, it could even cache dependency artifacts at higher optimization levels. This is particularly important for game development, data science, and procedural macros where debug builds of dependencies run *significantly* slower than their release variant. Projects like Bevy and WGPU explicitly guide developers to manually increase the optimization level of dependencies since the default is unusably slow for game and graphics development.
 
 Generally, a "high level Rust" would be fast-to-compile and maximally performant by default. The tweaks here do not require language changes and are generally a question of engineering effort rather than design consensus.
-
-
 ### The "shiny future" we are working towards
 
 A "high level Rust" would be a Rust that has a strong focus on iteration speed. Developers would benefit from Rust's performance, safety, and reliability guarantees without the current status quo of long compile times, verbose code, and program architecture limitations.
@@ -69,8 +63,6 @@ In our "shiny future," an aspiring genomics researcher would:
 - use various procedural macros with little compile-time cost
 - cleanly migrate their existing program architecture to Rust with few lifetime issues
 - employ various shortcuts like unwrap to get to running code quicker
-
-
 ## Design axioms[da]
 
 - Preference for minimally invasive changes that have the greatest potential benefit
@@ -84,8 +76,6 @@ In our "shiny future," an aspiring genomics researcher would:
 ## Ownership and team asks
 
 The work here is proposed by Jonathan Kelley on behalf of Dioxus Labs. We have funding for 1-2 engineers depending on the scope of work. Dioxus Labs is willing to take ownership and commit funding to solve these problems.
-
-
 | Task                         | Owner(s) or team(s) | Notes |
 |------------------------------|---------------------|-------|
 | proc macro expansion caching | [jkelleyrtp] + tbd  |       |

--- a/src/2024h2/flagship.md
+++ b/src/2024h2/flagship.md
@@ -2,4 +2,4 @@
 
 [Learn about flagship goals.](../about/flagship_goals.md)
 
-<!-- FLAGSHIP GOALS -->
+(((FLAGSHIP GOALS)))

--- a/src/2024h2/goals.md
+++ b/src/2024h2/goals.md
@@ -1,12 +1,12 @@
 # Goals
 
-This page lists the <!-- #GOALS --> project goals accepted for 2024h2.
+This page lists the (((#GOALS))) project goals accepted for 2024h2.
 
 ## Flagship goals
 
 Flagship goals represent the goals expected to have the broadest overall impact. 
 
-<!-- FLAGSHIP GOALS -->
+(((FLAGSHIP GOALS)))
 
 ## Other goals
 
@@ -14,4 +14,4 @@ This is the full list of goals (including flagship).
 
 **Invited goals.** Some goals here are marked with the ![Help wanted][] badge for their point of contact. These goals are called "invited goals". Teams have reserved some capacity to pursue these goals but until an appropriate owner is found they are only considered provisionally accepted. If you are interested in serving as the owner for one of these invited goals, reach out to the point of contact listed in the goal description.
 
-<!-- OTHER GOALS -->
+(((OTHER GOALS)))

--- a/src/2024h2/merged-doctests.md
+++ b/src/2024h2/merged-doctests.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @GuillaumeGomez                    |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#111] |
 | Zulip channel  | N/A                                |
-
-
 @GuillaumeGomez: https://github.com/GuillaumeGomez
 
 ## Motivation

--- a/src/2024h2/min_generic_const_arguments.md
+++ b/src/2024h2/min_generic_const_arguments.md
@@ -3,8 +3,6 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @BoxyUwU                           |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#100] |
 | Zulip channel  | [#project-const-generics][channel] |
@@ -45,11 +43,7 @@ The larger goal here is to lift most of the restrictions that const generics cur
     - implemented under `feature(generic_const_items)`, needs a bit of work to finish it. Becomes significantly more important *after* implementing `min_generic_const_args`
 - Introduce associated const equality bounds, e.g. `T: Trait<ASSOC = N>` to bring feature parity with associated types
     - implemented under `feature(associated_const_equality)`, blocked on allowing generic parameters in const generic arguments
-
-
 Allowing generic parameters to be used in const generic arguments is the only part of const generics that requires significant amounts of work while also having significant benefit. Everything else is already relatively close to the point of stabilization. I chose to specify this goal to be for implementing `min_generic_const_args` over "stabilize the easy stuff" as I would like to know whether the implementation of `min_generic_const_args` will surface constraints on the other features that may not be possible to easily fix in a backwards compatible manner. Regardless I expect these features will still progress while `min_generic_const_args` is being implemented.
-
-
 ## Design axioms
 
 - Do not block future extensions to const generics

--- a/src/2024h2/next-solver.md
+++ b/src/2024h2/next-solver.md
@@ -3,15 +3,11 @@
 | Metadata       |                                           |
 |----------------|-------------------------------------------|
 | Point of contact | @lcnr                                   |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                                  |
 | Tracking issue | [rust-lang/rust-project-goals#113]        |
 | Zulip channel  | [#t-types/trait-system-refactor][channel] |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor
-
-
 ## Summary
 
 In the next 6 months we plan to extend the next-generation trait solver as follows:
@@ -82,8 +78,6 @@ Add'l implementation work: @compiler-errors
 | Implementation (rust-analyzer side) | TBD                       |       |
 | Standard reviews                    | ![Team][] [types]         |       |
 | Standard reviews                    | ![Team][] [rust-analyzer] |       |
-
-
 ### Support needed from the project
 
 * [Types] team

--- a/src/2024h2/not_accepted.md
+++ b/src/2024h2/not_accepted.md
@@ -2,4 +2,4 @@
 
 This section contains goals that were proposed but ultimately not accepted, either for want of resources or consensus. In many cases, narrower versions of these goals were accepted.
 
-<!-- GOALS NOT ACCEPTED -->
+(((GOALS NOT ACCEPTED)))

--- a/src/2024h2/optimize-clippy.md
+++ b/src/2024h2/optimize-clippy.md
@@ -4,13 +4,9 @@
 | Metadata       |                                    |
 |----------------|------------------------------------|
 | Point of contact | @blyxyas                           |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#114] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 This is the formalization and documentation of the Clippy Performance Project, a project first talked about on [Zulip, July 2023](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Clippy's.20performance). As the project consists of several points and is ever-changing, this document also has a dynamic structure and the team can add points. 
@@ -30,8 +26,6 @@ The usage for IDEs is not as smooth as one may desire or expect when comparing t
 The other big use-case is as a test before committing or on CI. Optimizing Clippy for performance would fold the cost of these tests.
 
 On GitHub Actions, this excessive time can equal the cost of running `cargo check` on a Linux x64 32-cores machine, instead of a Linux x64 2-cores machine. A 3.3x cost increase.
-
-
 <!-- *Elaborate in more detail about the problem you are trying to solve. This section is making the case for why this particular problem is worth prioritizing with project bandwidth. A strong status quo section will (a) identify the target audience and (b) give specifics about the problems they are facing today. Sometimes it may be useful to start sketching out how you think those problems will be addressed by your change, as well, though it's not necessary.* -->
 
 ### The next 6 months

--- a/src/2024h2/parallel-front-end.md
+++ b/src/2024h2/parallel-front-end.md
@@ -3,15 +3,11 @@
 | Metadata       |                                          |
 | ---            | ---                                      |
 | Point of contact | @SparrowLii                            |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                                 |
 | Tracking issue | [rust-lang/rust-project-goals#121]       |
 | Zulip channel  | [#t-compiler/wg-parallel-rustc][channel] |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fwg-parallel-rustc/
-
-
 ## Summary
 
 We will move rustc's support for parallel front end closer to stability by resolving [ICE] and [deadlock] issues, completing the [test] suite for multithreaded scenario and integrating parallel front end into bootstrap. This fits into our larger goal of improving rustc build times by 20% by leveraging multiple cores and enhance its robustness.
@@ -66,8 +62,6 @@ The parallel front end should be:
 | Discussion and moral support | ![Team][] [compiler] |       |
 
 ## Frequently asked questions
-
-
 [ICE]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AWG-compiler-parallel+ice
 [deadlock]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AWG-compiler-parallel+deadlock
 [test]: https://github.com/rust-lang/rust/issues/118698

--- a/src/2024h2/pubgrub-in-cargo.md
+++ b/src/2024h2/pubgrub-in-cargo.md
@@ -3,23 +3,15 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @eh2406                            |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#110] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Implement a standalone library based on pubgrub that model's cargo dependency resolution and validate its accurate with testing against crates found on crates.io. This lays the groundwork for improved cargo error messages, extensions for hotly requested features (e.g., better MSRV support, CVE-aware resolution, etc), and support for a richer ecosystem of cargo extensions.
 
 ## Motivation
-
-
 Cargo's dependency resolver is brittle and under-tested. Disentangling implementation details, performance optimizations, and user-facing functionality will require a rewrite. Making the resolver a standalone modular library will make it easier to test and maintain.
-
-
 ### The status quo
 
 Big changes are required in cargo's resolver: there is lots of new functionality that will require changes to the resolver and the existing resolver's error messages are terrible. Cargo's dependency resolver solves the NP-Hard problem of taking a list of direct dependencies and an index of all available crates and returning an exact list of versions that should be built. This functionality is exposed in cargo's CLI interface as generating/updating a lock file. Nonetheless, any change to the current resolver in situ is extremely treacherous. Because the problem is NP-Hard it is not easy to tell what code changes break load-bearing performance or correctness guarantees. It is difficult to abstract and separate the existing resolver from the code base, because the current resolver relies on concrete datatypes from other modules in cargo to determine if a set of versions have any of the many ways two crate versions can be incompatible.

--- a/src/2024h2/rfl_stable.md
+++ b/src/2024h2/rfl_stable.md
@@ -4,7 +4,8 @@
 |------------------|------------------------------------|
 | Short title      | Rust-for-Linux                     |
 | Point of contact | @nikomatsakis                      |
-| Status           | Flagship                           |
+| Status           | Accepted                           |
+| Flagship         | Yes                                |
 | Tracking issue   | [rust-lang/rust-project-goals#116] |
 | Zulip channel    | [#rust-for-linux][channel]         |
 

--- a/src/2024h2/rfl_stable.md
+++ b/src/2024h2/rfl_stable.md
@@ -4,8 +4,6 @@
 |------------------|------------------------------------|
 | Short title      | Rust-for-Linux                     |
 | Point of contact | @nikomatsakis                      |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status           | Flagship                           |
 | Tracking issue   | [rust-lang/rust-project-goals#116] |
 | Zulip channel    | [#rust-for-linux][channel]         |
@@ -190,8 +188,6 @@ Here is a detailed list of the work to be done and who is expected to do it. Thi
 |------------------------|---------------------|-------|
 | Stabilization report   |                     |       |
 | Stabilization decision | ![Team][] [lang]    |       |
-
-
 ### Support needed from the project
 
 * Lang team:
@@ -210,5 +206,3 @@ Here is a detailed list of the work to be done and who is expected to do it. Thi
 ## Frequently asked questions
 
 None yet.
-
-

--- a/src/2024h2/rustdoc-search.md
+++ b/src/2024h2/rustdoc-search.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 |----------------|------------------------------------|
 | Point of contact | @notriddle                         |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#112] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 To make rustdoc's search engine more useful:

--- a/src/2024h2/sandboxed-build-script.md
+++ b/src/2024h2/sandboxed-build-script.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @weihanglo                         |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#108] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Explore different strategies for sandboxing build script executions in Cargo.

--- a/src/2024h2/std-verification.md
+++ b/src/2024h2/std-verification.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 | ---            | ---                                |
 | Point of contact | @celinval                          |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#126] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Instrument a fork of the standard library (the [verify-rust-std] repository) with safety contracts,

--- a/src/2024h2/user-wide-cache.md
+++ b/src/2024h2/user-wide-cache.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |------------------|------------------------------------|
 | Point of contact | @epage                             |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status           | Invited                            |
 | Tracking issue   | [rust-lang/rust-project-goals#124] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Extend Cargo's caching of intermediate artifacts across a workspace to caching them across all workspaces of the user.

--- a/src/2024h2/yank-crates-with-a-reason.md
+++ b/src/2024h2/yank-crates-with-a-reason.md
@@ -3,13 +3,9 @@
 | Metadata       |                                    |
 |----------------|------------------------------------|
 | Point of contact | @Rustin170506                      |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status         | Accepted                           |
 | Tracking issue | [rust-lang/rust-project-goals#101] |
 | Zulip channel  | N/A                                |
-
-
 ## Summary
 
 Over the next 6 months, we will add support to the registry yank API for providing a reason when a crate is yanked. This reason can then be displayed to users. After this feature has been up and running for a while, we'll open it up to Cargo to support filling in the reason for yanking.
@@ -29,8 +25,6 @@ This feature has the following potential use cases:
 3. If a crate is renamed (or perhaps deprecated) to another then the yank message can indicate what to do in that situation.
 
 Additionally, if we can persist this information to the crates.io index, we can make it available as meta-information to other platforms, such as security platforms like RustSec.
-
-
 ### The next 6 months
 
 The primary goal for the next 6 months is to add support to the registry's [yank API].

--- a/src/2025h1/GPU-Offload.md
+++ b/src/2025h1/GPU-Offload.md
@@ -3,16 +3,11 @@
 | Metadata              |                                                  |
 |:----------------------|--------------------------------------------------|
 | Point of contact      | @ZuseZ4                                          |
-| Teams                 | <!-- TEAMS WITH ASKS -->                         |
-| Task owners           | <!-- TASK OWNERS -->                             |
 | Status                | Accepted                                         |
 | Tracking issue        | [rust-lang/rust-project-goals#109]               |
 | Other tracking issues | [rust-lang/rust#124509], [rust-lang/rust#124509] |
 | Zulip channel         | [#wg-autodiff][channel]                          |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/390790-wg-autodiff
-
-
 ## Summary
 
 Expose experimental LLVM features for GPU offloading and allow combining it with the `std::autodiff` feature.

--- a/src/2025h1/Polonius.md
+++ b/src/2025h1/Polonius.md
@@ -3,15 +3,10 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @lqd                               |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#118] |
 | Zulip channel    | [#t-types/polonius][channel]       |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/186049-t-types.2Fpolonius
-
-
 ## Summary
 
 Keep working on implementing a native rustc version of the [Polonius][pc3] next generation borrow checking algorithm, that would scale better than the previous [datalog] implementation, continuing from the [2024h2 goal](https://rust-lang.github.io/rust-project-goals/2024h2/Polonius.html).

--- a/src/2025h1/README.md
+++ b/src/2025h1/README.md
@@ -17,8 +17,6 @@ Propose a slate of <!-- #GOALS --> project goals for 2025H1, including 3 flagshi
 * Address the biggest concerns raised by Rust maintainers, lack of face-to-face interaction, by [**organizing the Rust All-Hands 2025**](./all-hands.md). In 2025H1 we plan to:
     * convene Rust maintainers to celebrate Rust's tenth birthday at [RustWeek 2025](https://2025.rustweek.org) (co-organized with [RustNL](https://2025.rustweek.org/about/));
     * author a first draft for a [Rust vision doc](./rust-vision-doc.md) and gather feedback.
-
-
 ## Motivation
 
 The 2025H1 goal slate consists of <!-- #GOALS --> project goals, of which we have selected 3 as **flagship goals**. Flagship goals represent the goals expected to have the broadest overall impact.

--- a/src/2025h1/README.md
+++ b/src/2025h1/README.md
@@ -1,8 +1,8 @@
-> ![Status: Accepted](https://img.shields.io/badge/Status-Accepted-green) [RFC #3764] has been **accepted**, establishing [<!-- #GOALS --> total Rust project goals for 2025H1](./goals.md).
+> ![Status: Accepted](https://img.shields.io/badge/Status-Accepted-green) [RFC #3764] has been **accepted**, establishing [(((#GOALS))) total Rust project goals for 2025H1](./goals.md).
 
 ## Summary
 
-Propose a slate of <!-- #GOALS --> project goals for 2025H1, including 3 flagship goals:
+Propose a slate of (((#GOALS))) project goals for 2025H1, including 3 flagship goals:
 
 * Continue making Rust easier to use for network systems by [**bringing the Async Rust experience closer to parity with sync Rust**](./async.md). In 2025H1 we plan to:
     * tell a complete story for the use of async fn in traits, unblocking wide ecosystem adoption;
@@ -19,7 +19,7 @@ Propose a slate of <!-- #GOALS --> project goals for 2025H1, including 3 flagshi
     * author a first draft for a [Rust vision doc](./rust-vision-doc.md) and gather feedback.
 ## Motivation
 
-The 2025H1 goal slate consists of <!-- #GOALS --> project goals, of which we have selected 3 as **flagship goals**. Flagship goals represent the goals expected to have the broadest overall impact.
+The 2025H1 goal slate consists of (((#GOALS))) project goals, of which we have selected 3 as **flagship goals**. Flagship goals represent the goals expected to have the broadest overall impact.
 
 ### How the goal process works
 
@@ -85,7 +85,7 @@ The full slate of project goals are as follows. These goals all have identified 
 
 **Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as an owner. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- GOALS -->
+(((GOALS)))
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -95,7 +95,7 @@ The rows are goals and columns are [asks being made of the team][valid_team_asks
 The contents of each cell may contain extra notes (or sometimes footnotes) with more details.
 Teams often use these notes to indicate the person on the team signed up to do the work, for example.
 
-<!-- TEAM ASKS -->
+(((TEAM ASKS)))
 
 ### Definitions
 
@@ -137,7 +137,7 @@ Definitions for terms used above:
 
 The following goals were proposed but ultimately not accepted, either for want of resources or consensus. In some cases narrower versions of these goals were prepared.
 
-<!-- GOALS NOT ACCEPTED -->
+(((GOALS NOT ACCEPTED)))
 
 ## What do the column names like "Ded. r?" mean?
 
@@ -145,6 +145,6 @@ The following goals were proposed but ultimately not accepted, either for want o
 
 Those column names refer to specific things that can be asked of teams:
 
-<!-- VALID TEAM ASKS -->
+(((VALID TEAM ASKS)))
 
 <!-- Github usernames -->

--- a/src/2025h1/all-hands.md
+++ b/src/2025h1/all-hands.md
@@ -3,7 +3,8 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @m-ou-se                           |
-| Status             | Flagship                           |
+| Status             | Accepted                           |
+| Flagship         | Yes                                |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#263] |
 

--- a/src/2025h1/all-hands.md
+++ b/src/2025h1/all-hands.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @m-ou-se                           |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Flagship                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#263] |

--- a/src/2025h1/annotate-snippets.md
+++ b/src/2025h1/annotate-snippets.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @Muscraft                          |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#123] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 Switch to annotate-snippets for rendering rustc's output, with no loss of functionality or visual regressions.
@@ -37,8 +33,6 @@ The outputs of rustc and cargo are fully using annotate-snippets, with no regres
 
 - **Match rustc's output**: The output of annotate-snippets should match rustc, modulo reasonable non-significant divergences
 - **Works for Cargo (and other tools)**: annotate-snippets is meant to be used by any project that would like "Rust-style" output, so it should be designed to work with any project, not just rustc.
-
-
 [da]: https://rust-lang.github.io/rust-project-goals/about/design_axioms.html
 
 ## Ownership and team asks
@@ -82,6 +76,4 @@ The outputs of rustc and cargo are fully using annotate-snippets, with no regres
 | Task                                       | Owner(s) or team(s) | Notes |
 |--------------------------------------------|---------------------|-------|
 | Top-level Rust blog post inviting feedback |                     |       |
-
-
 [cargo-lints]: https://github.com/rust-lang/cargo/issues/12235

--- a/src/2025h1/arm-sve-sme.md
+++ b/src/2025h1/arm-sve-sme.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @davidtwco                         |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#270] |

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -4,7 +4,8 @@
 |:-----------------|------------------------------------|
 | Short title      | Async                              |
 | Point of contact | @tmandry                           |
-| Status           | Flagship                           |
+| Status           | Accepted                           |
+| Flagship         | Yes                                |
 | Tracking issue   | [rust-lang/rust-project-goals#105] |
 | Zulip channel    | [#wg-async][channel]               |
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/

--- a/src/2025h1/async.md
+++ b/src/2025h1/async.md
@@ -4,15 +4,10 @@
 |:-----------------|------------------------------------|
 | Short title      | Async                              |
 | Point of contact | @tmandry                           |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Flagship                           |
 | Tracking issue   | [rust-lang/rust-project-goals#105] |
 | Zulip channel    | [#wg-async][channel]               |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
-
-
 ## Summary
 
 Over the next six months, we will continue bringing Async Rust up to par with "sync Rust" by doing the following:

--- a/src/2025h1/build-std.md
+++ b/src/2025h1/build-std.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @davidtwco                         |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#274] |

--- a/src/2025h1/cargo-plumbing.md
+++ b/src/2025h1/cargo-plumbing.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Invited                            |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#264] |

--- a/src/2025h1/cargo-script.md
+++ b/src/2025h1/cargo-script.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @epage                                                                           |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Accepted                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#119]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Stabilize support for "cargo script", the ability to have a single file that contains both Rust code and a `Cargo.toml`.

--- a/src/2025h1/cargo-semver-checks.md
+++ b/src/2025h1/cargo-semver-checks.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @obi1kenobi                        |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#104] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 Design and implement `cargo-semver-checks` functionality that lies on the critical path for merging the tool into cargo itself. Continues the work of [the 2024h2 goal][2024h2-goal].

--- a/src/2025h1/compiletest-directive-rework.md
+++ b/src/2025h1/compiletest-directive-rework.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @jieyouxu                          |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#259] |

--- a/src/2025h1/const-trait.md
+++ b/src/2025h1/const-trait.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @oli-obk                           |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#106] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 Prepare `const Trait` bounds for stabilization.
@@ -102,4 +98,3 @@ Definitions for terms used above:
 ### Will we be stabilizing the syntax found on libstd today?
 
 Most likely not. The current syntax includes some controversial notation, such as `T: ~Trait`. The point of the RFC is to determine what syntax will be used. What we hope will not change is the *semantics*.
-

--- a/src/2025h1/eii.md
+++ b/src/2025h1/eii.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @m-ou-se                           |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#254] |

--- a/src/2025h1/ergonomic-rc.md
+++ b/src/2025h1/ergonomic-rc.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @spastorino                        |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#107] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 * Deliver a nightly implementation of the experimental `use` syntax for ergonomic ref-counting.

--- a/src/2025h1/field-projections.md
+++ b/src/2025h1/field-projections.md
@@ -3,11 +3,8 @@
 | Metadata         |                            |
 |:-----------------|----------------------------|
 | Point of contact | @y86-dev                   |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status           | Not accepted                   |
 | Zulip channel    | N/A                        |
-
 ## Summary
 
 Finalize the [Field Projections RFC] and implement it for use in nightly.

--- a/src/2025h1/formality.md
+++ b/src/2025h1/formality.md
@@ -3,12 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @nikomatsakis                      |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#122] |
 | Zulip channel    | [#t-types/formality][channel]      |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality
 
 ## Summary

--- a/src/2025h1/goals.md
+++ b/src/2025h1/goals.md
@@ -1,6 +1,6 @@
 # Goals
 
-This page lists the <!-- #GOALS --> project goals **proposed** for 2025h1.
+This page lists the (((#GOALS))) project goals **proposed** for 2025h1.
 
 > Just because a goal is listed on this list does not mean the goal has been accepted.
 > The owner of the goal process makes the final decisions on which goals to include
@@ -10,7 +10,7 @@ This page lists the <!-- #GOALS --> project goals **proposed** for 2025h1.
 
 Flagship goals represent the goals expected to have the broadest overall impact. [Learn about flagship goals.](../about/flagship_goals.md)
 
-<!-- FLAGSHIP GOALS -->
+(((FLAGSHIP GOALS)))
 
 ## Other goals
 
@@ -18,4 +18,4 @@ These are the other proposed goals.
 
 **Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as an owner. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- OTHER GOALS -->
+(((OTHER GOALS)))

--- a/src/2025h1/improve-rustc-codegen.md
+++ b/src/2025h1/improve-rustc-codegen.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @folkertdev                        |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#258] |
@@ -79,8 +77,6 @@ The shiny future is to improve rust codegen to encourage wider adoption of rust 
 | Refine RFC 3720              | @folkertdev          |       |
 | Implementation               | @folkertdev, @bjorn3 |       |
 | Standard reviews             | ![Team][] [compiler] |       |
-
-
 ### Definitions
 
 Definitions for terms used above:

--- a/src/2025h1/libtest-json.md
+++ b/src/2025h1/libtest-json.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#255] |

--- a/src/2025h1/macro-improvements.md
+++ b/src/2025h1/macro-improvements.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @joshtriplett                      |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#252] |
@@ -128,8 +126,6 @@ could reserve such syntax in all editions.
 ## Ownership and team asks
 
 **Owner / Responsible Reporting Party:** @joshtriplett
-
-
 | Task                                   | Owner(s) or team(s)          | Notes                                                                                                           |
 |----------------------------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | Propose discussion session at RustWeek | @joshtriplett                |                                                                                                                 |

--- a/src/2025h1/metrics-initiative.md
+++ b/src/2025h1/metrics-initiative.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @yaahc                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#260] |
@@ -81,6 +79,4 @@ We'd like to get to the point where lang and libs can pull up a simple dashboard
 | integration with docs.rs or crates.io to gather metrics from open source rust projects | @yaahc                        |       |
 | proof of concept dashboard visualizing unstable feature usage data                     | ![Help Wanted][]              |       |
 | Standard reviews                                                                       | ![Team][] [compiler]          |       |
-
-
 ## Frequently asked questions

--- a/src/2025h1/min_generic_const_arguments.md
+++ b/src/2025h1/min_generic_const_arguments.md
@@ -3,15 +3,10 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @BoxyUwU                           |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#100] |
 | Zulip channel    | [#project-const-generics][channel] |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/260443-project-const-generics/
-
-
 ## Summary
 
 Experiment with a new `min_generic_const_args` implementation to address challenges found with the existing approach to supporting generic parameters in const generic arguments.

--- a/src/2025h1/next-solver.md
+++ b/src/2025h1/next-solver.md
@@ -3,15 +3,10 @@
 | Metadata         |                                           |
 |:-----------------|-------------------------------------------|
 | Point of contact | @lcnr                                     |
-| Teams            | <!-- TEAMS WITH ASKS -->                  |
-| Task owners      | <!-- TASK OWNERS -->                      |
 | Status           | Accepted                                  |
 | Tracking issue   | [rust-lang/rust-project-goals#113]        |
 | Zulip channel    | [#t-types/trait-system-refactor][channel] |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor
-
-
 ## Summary
 
 Continue work towards the stabilization of `-Znext-solver=globally`, collecting and resolving remaining blockers. Extend its use in lints and rustdoc.
@@ -39,8 +34,6 @@ Fixing these issues in the existing implementation is prohibitively difficult as
 - go through the most popular crates on crates.io and fix any encountered issues
 - move additional lints and rustdoc to use the new solver by default
 - publicly ask for testing of `-Znext-solver=globally` once that's useful
-
-
 ### The "shiny future" we are working towards
 
 - we are able to remove the existing trait solver implementation and significantly cleanup the type system in general, e.g. removing most `normalize` in the caller by handling unnormalized types in the trait system

--- a/src/2025h1/not_accepted.md
+++ b/src/2025h1/not_accepted.md
@@ -2,4 +2,4 @@
 
 This section contains goals that were proposed but ultimately not accepted, either for want of resources or consensus. In many cases, narrower versions of these goals were proposed instead.
 
-<!-- GOALS NOT ACCEPTED -->
+(((GOALS NOT ACCEPTED)))

--- a/src/2025h1/null-enum-discriminant-debug-checks.md
+++ b/src/2025h1/null-enum-discriminant-debug-checks.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @1c3t3a                            |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#262] |

--- a/src/2025h1/open-namespaces.md
+++ b/src/2025h1/open-namespaces.md
@@ -1,11 +1,7 @@
 # Implement Open API Namespace Support
-
-
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Invited                            |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#256] |

--- a/src/2025h1/optimize-clippy-linting-2.md
+++ b/src/2025h1/optimize-clippy-linting-2.md
@@ -4,13 +4,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @blyxyas                           |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#114] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 This is the formalization and documentation of the Clippy Performance Project, a project first talked about on [Zulip, July 2023](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Clippy's.20performance). As the project consists of several points and is ever-changing, this document also has a dynamic structure and the team can add points. 
@@ -30,8 +26,6 @@ The usage for IDEs is not as smooth as one may desire or expect when comparing t
 The other big use-case is as a test before committing or on CI. Optimizing Clippy for performance would fold the cost of these tests.
 
 On GitHub Actions, this excessive time can equal the cost of running `cargo check` on a Linux x64 32-cores machine, instead of a Linux x64 2-cores machine. A 3.3x cost increase.
-
-
 <!-- *Elaborate in more detail about the problem you are trying to solve. This section is making the case for why this particular problem is worth prioritizing with project bandwidth. A strong status quo section will (a) identify the target audience and (b) give specifics about the problems they are facing today. Sometimes it may be useful to start sketching out how you think those problems will be addressed by your change, as well, though it's not necessary.* -->
 
 ### The next 6 months
@@ -60,8 +54,6 @@ A developer shouldn't have to get a high-end machine to run a compiler swiftly; 
 |-------------------|----------------------|-------|
 | Implementation    | @blyxyas, @Alexendoo |       |
 | Standard reviews  | ![Team][] [clippy]   |       |
-
-
 [pr125116]: https://github.com/rust-lang/rust/pull/125116
 [poll-urlo]: https://users.rust-lang.org/t/feedback-poll-where-and-how-do-you-use-clippy/114047?u=blyxyas
 [poll-reddit]: https://www.reddit.com/r/rust/comments/1dxu43p/feedback_poll_where_how_do_you_use_clippy/

--- a/src/2025h1/parallel-front-end.md
+++ b/src/2025h1/parallel-front-end.md
@@ -3,15 +3,10 @@
 | Metadata         |                                          |
 |:-----------------|------------------------------------------|
 | Point of contact | @SparrowLii                              |
-| Teams            | <!-- TEAMS WITH ASKS -->                 |
-| Task owners      | <!-- TASK OWNERS -->                     |
 | Status           | Accepted                                 |
 | Tracking issue   | [rust-lang/rust-project-goals#121]       |
 | Zulip channel    | [#t-compiler/wg-parallel-rustc][channel] |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fwg-parallel-rustc/
-
-
 ## Summary
 
 Continue to parallelize front-end stabilization and performance improvements, continuing from the [2024h2 goal](https://rust-lang.github.io/rust-project-goals/2024h2/parallel-front-end.html).
@@ -65,8 +60,6 @@ The parallel front end should be:
 | Discussion and moral support | ![Team][] [compiler] |       |
 
 ## Frequently asked questions
-
-
 [ICE]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AWG-compiler-parallel+ice
 [deadlock]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AWG-compiler-parallel+deadlock
 [test]: https://github.com/rust-lang/rust/issues/118698

--- a/src/2025h1/perf-improvements.md
+++ b/src/2025h1/perf-improvements.md
@@ -3,8 +3,6 @@
 | Metadata           |                                                          |
 | :--                | :--                                                      |
 | Point of contact   | @davidtwco                                               |
-| Teams              | <!-- TEAMS WITH ASKS -->                                 |
-| Task owners        | <!-- TASK OWNERS -->                                     |
 | Status             | Accepted                                                 |
 | Zulip channel      | [#project-goals/2025h1/rustc-perf-improvements][channel] |
 | Tracking issue     | [rust-lang/rust-project-goals#275]                       |

--- a/src/2025h1/pub-priv.md
+++ b/src/2025h1/pub-priv.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Invited                            |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#272] |

--- a/src/2025h1/pubgrub-in-cargo.md
+++ b/src/2025h1/pubgrub-in-cargo.md
@@ -3,23 +3,15 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @eh2406                            |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#110] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 Implement a standalone library based on pubgrub that model's cargo dependency resolution and bring it to a quality of code so that it can be maintained by the cargo team. This lays the groundwork for improved cargo error messages, extensions for hotly requested features (e.g., better MSRV support, CVE-aware resolution, etc), and support for a richer ecosystem of cargo extensions.
 
 ## Motivation
-
-
 Cargo's dependency resolver is brittle and under-tested. Disentangling implementation details, performance optimizations, and user-facing functionality will require a rewrite. Making the resolver a standalone modular library will make it easier to test and maintain.
-
-
 ### The status quo
 
 Big changes are required in cargo's resolver: there is lots of new functionality that will require changes to the resolver and the existing resolver's error messages are terrible. Cargo's dependency resolver solves the NP-Hard problem of taking a list of direct dependencies and an index of all available crates and returning an exact list of versions that should be built. This functionality is exposed in cargo's CLI interface as generating/updating a lock file. Nonetheless, any change to the current resolver in situ is extremely treacherous. Because the problem is NP-Hard it is not easy to tell what code changes break load-bearing performance or correctness guarantees. It is difficult to abstract and separate the existing resolver from the code base, because the current resolver relies on concrete datatypes from other modules in cargo to determine if a set of versions have any of the many ways two crate versions can be incompatible.

--- a/src/2025h1/restrictions.md
+++ b/src/2025h1/restrictions.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @jhpratt                           |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#257] |

--- a/src/2025h1/rfl.md
+++ b/src/2025h1/rfl.md
@@ -4,15 +4,10 @@
 |:-----------------|------------------------------------|
 | Short title      | Rust-for-Linux                     |
 | Point of contact | @nikomatsakis                      |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Flagship                           |
 | Tracking issue   | [rust-lang/rust-project-goals#116] |
 | Zulip channel    | [#rust-for-linux][channel]         |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux/
-
-
 ## Summary
 
 Continue working towards Rust for Linux on stable, turning focus to compiler and tooling.

--- a/src/2025h1/rfl.md
+++ b/src/2025h1/rfl.md
@@ -4,7 +4,8 @@
 |:-----------------|------------------------------------|
 | Short title      | Rust-for-Linux                     |
 | Point of contact | @nikomatsakis                      |
-| Status           | Flagship                           |
+| Status           | Accepted                           |
+| Flagship         | Yes                                |
 | Tracking issue   | [rust-lang/rust-project-goals#116] |
 | Zulip channel    | [#rust-for-linux][channel]         |
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux/

--- a/src/2025h1/rust-vision-doc.md
+++ b/src/2025h1/rust-vision-doc.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @nikomatsakis                      |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#269] |

--- a/src/2025h1/safe-linking.md
+++ b/src/2025h1/safe-linking.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @m-ou-se                           |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#267] |

--- a/src/2025h1/seamless-rust-cpp.md
+++ b/src/2025h1/seamless-rust-cpp.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :----------------- | ------------------------------     |
 | Point of contact   | @tmandry                           |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#253] |

--- a/src/2025h1/simd-multiversioning.md
+++ b/src/2025h1/simd-multiversioning.md
@@ -3,15 +3,11 @@
 | Metadata           |                                     |
 | :--                | :--                                 |
 | Point of contact   | @veluca93                           |
-| Teams              | <!-- TEAMS WITH ASKS -->            |
-| Task owners        | <!-- TASK OWNERS -->                |
 | Status             | Accepted                            |
 | Zulip channel      | [#project-portable-simd][channel]   |
 | Tracking issue     | [rust-lang/rust-project-goals#261]  |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/257879-project-portable-simd/
-
-
 ## Summary
 
 Figure out the best way for Rust to support generating code for multiple SIMD targets in a safe and ergonomic way.
@@ -23,8 +19,6 @@ Most libraries that are shipped to users in binary form thus tend to contain cod
 Having compiler support for this pattern, i.e. by having the compiler generate multiple versions of code written only once, would significantly help drive Rust's adoption in the world of codecs, where some of the [most subtle](https://blog.isosceles.com/the-webp-0day/) memory vulnerabilities are found, as well as other domains where squeezing out the last bits of performance is fundamental.
 
 [^avx512]: For example, `x86` CPUs currently have about [12](https://en.wikipedia.org/wiki/AVX-512#CPUs_with_AVX-512) (!) different possible configurations with respect to AVX-512 support alone.
-
-
 ### The status quo
 
 Currently, generating efficient code for a specific SIMD ISAs requires annotating the function with appropriate attributes. This is incompatible with generating multiple versions through i.e. generics.
@@ -74,8 +68,6 @@ This significantly increases the adoption of Rust in performance-critical, safet
 | Experimental implementation | @veluca93           |       |
 | Author RFC                  | @veluca93           |       |
 | RFC decision                | ![Team][] [lang]    |       |
-
-
 ### Definitions
 
 Definitions for terms used above:

--- a/src/2025h1/spec-fls-publish.md
+++ b/src/2025h1/spec-fls-publish.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @joelmarcey                        |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | [#t-spec][channel]                 |
 | Tracking issue     | [rust-lang/rust-project-goals#265] |

--- a/src/2025h1/spec-testing.md
+++ b/src/2025h1/spec-testing.md
@@ -3,11 +3,8 @@
 | Metadata         |                    |
 |:-----------------|--------------------|
 | Point of contact | @chorman0773       |
-| Teams | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status           | Not accepted           |
 | Zulip channel    | [#t-spec][channel] |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/399173-t-spec
 
 ## Summary
@@ -34,13 +31,9 @@ The integration of testing into the specification should:
 * Aid the development of the Rust Language, and to assist improvements to the processes being considered by the Language Team,
 * Aid the development of the Rust Compiler and its test suite as a whole, by improving organization of the test suite, including differentiating between tests of language-level guaranteed behaviour and tests of implementation-specific behaviour, and
 * Aid in the use of the Rust Specification in the context of safety-critical development, by providing traceability for the content of the Specification. 
-
-
 ## Ownership and team asks
 
 **Owner:** Connor Horman
-
-
 | Task                 | Owner(s) or team(s)                                    | Notes     |
 |----------------------|--------------------------------------------------------|-----------|
 | Author RFC           | @chorman0773                                           |           |
@@ -50,4 +43,3 @@ The integration of testing into the specification should:
 | Author new tests     | @chorman0773                                           |           |
 
 ## Frequently asked questions
-

--- a/src/2025h1/stabilize-project-goal-program.md
+++ b/src/2025h1/stabilize-project-goal-program.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @nikomatsakis                      |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | [#project-goals][channel]          |
 | Tracking issue     | [rust-lang/rust-project-goals#268] |

--- a/src/2025h1/stable-mir.md
+++ b/src/2025h1/stable-mir.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @celinval                          |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | [#project-stable-mir][channel]     |
 | Tracking issue     | [rust-lang/rust-project-goals#266] |
@@ -70,8 +68,6 @@ fostering innovation and reducing bottlenecks.
 - Crates should follow semantic versioning.
 
 ## Ownership and team asks
-
-
 | Task                         | Owner(s) or team(s)            | Notes |
 |------------------------------|--------------------------------|-------|
 | Discussion and moral support | ![Team][] [compiler]           |       |

--- a/src/2025h1/std-contracts.md
+++ b/src/2025h1/std-contracts.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @celinval                          |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#126] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 Finish the implementation of the contract attributes proposed in the compiler [MCP-759],
@@ -90,8 +86,6 @@ unless users opt-in for contract runtime checks.
 | Standard Library Contracts | @celinval, @tautschnig |       |
 | Writing new contracts      | ![Help wanted][]       |       |
 | Standard reviews           | ![Team][] [libs]       |       |
-
-
 ### Definitions
 
 Definitions for terms used above:

--- a/src/2025h1/unsafe-fields.md
+++ b/src/2025h1/unsafe-fields.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @jswrenn                           |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#273] |

--- a/src/2025h1/verification-and-mirroring.md
+++ b/src/2025h1/verification-and-mirroring.md
@@ -4,8 +4,6 @@
 | :--                | :--                                |
 | Short title        | Crates.io mirroring                |
 | Point of contact   | @walterhpearce                     |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Accepted                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#271] |
@@ -69,8 +67,6 @@ We also wish to implement technical items for this goal.
 - We will have integrated signing into a TUF repository for crates published to crates.io; this may be accomplished in collaboration with crates.io or out-of-band via the new updates RSS feed.
 
 - Finally, we'll provide some method for end users to verify these signatures as an external cargo subcommand & rustup fork for proof-of-concept
-
-
 ### The "shiny future" we are working towards
 
 After this next six months, we will continue working to bring the experimental infrastructure into production.

--- a/src/2025h2/FLS-up-to-date-capabilities.md
+++ b/src/2025h2/FLS-up-to-date-capabilities.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @JoelMarcey                                                                      |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | #t-spec                                                                          |
-
 ## Summary
 
 Develop the capabilities and capacity to keep the FLS up to date with the Rust language.

--- a/src/2025h2/README.md
+++ b/src/2025h2/README.md
@@ -7,7 +7,7 @@ This is a draft for the eventual RFC proposing the 2025h2 goals.
 
 ## Motivation
 
-The 2025h2 goal slate consists of <!-- #GOALS --> project goals, of which we have selected (TBD) as **flagship goals**. Flagship goals represent the goals expected to have the broadest overall impact.
+The 2025h2 goal slate consists of (((#GOALS))) project goals, of which we have selected (TBD) as **flagship goals**. Flagship goals represent the goals expected to have the broadest overall impact.
 
 ### How the goal process works
 
@@ -54,7 +54,7 @@ The full slate of project goals are as follows. These goals all have identified 
 
 **Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as a point of contact. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- GOALS -->
+(((GOALS)))
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -62,7 +62,7 @@ The full slate of project goals are as follows. These goals all have identified 
 The following table highlights the asks from each affected team.
 The "owner" in the column is the person expecting to do the design/implementation work that the team will be approving.
 
-<!-- TEAM ASKS -->
+(((TEAM ASKS)))
 
 ### Definitions
 

--- a/src/2025h2/README.md
+++ b/src/2025h2/README.md
@@ -1,6 +1,4 @@
 # Rust project goals 2025h2
-
-
 ## Summary
 
 *![Status: Accepting goal proposals](https://img.shields.io/badge/Status-Accepting%20goal%20proposals-yellow) We are in the process of assembling the goal slate.*

--- a/src/2025h2/Rust-for-Linux-compiler.md
+++ b/src/2025h2/Rust-for-Linux-compiler.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @tomassedovic                                                                    |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#116]                                               |
 | Zulip channel    | [#t-compiler][channel-t-compiler], [#rust-for-linux][channel-rust-for-linux]     |
-
 [channel-t-compiler]: https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler
 [channel-rust-for-linux]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux
 

--- a/src/2025h2/Rust-for-Linux-language.md
+++ b/src/2025h2/Rust-for-Linux-language.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @tomassedovic                                                                    |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#116]                                               |
 | Zulip channel    | [#t-lang][channel-t-lang], [#rust-for-linux][channel-rust-for-linux]             |
-
 [channel-t-lang]: https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang
 [channel-rust-for-linux]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux
 

--- a/src/2025h2/a-mir-formality.md
+++ b/src/2025h2/a-mir-formality.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @nikomatsakis                                                                    |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#122]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Extend a-mir-formality with the ability to represent function bodies as MiniRust programs; a type checker based on the MIR type checker from the compiler; and a model that covers key parts of the the Polonius Alpha proposal.

--- a/src/2025h2/autoreborrow-traits.md
+++ b/src/2025h2/autoreborrow-traits.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @aapoalas                                                                        |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Bring up a language RFC for autoreborrow traits and land nightly support for the traits.
@@ -113,8 +110,6 @@ struct X<'a, 'b> {
 To enable this, reborrowing needs to be defined as a recursive operation but what the "bottom-case" is, that
 is the question. One option would be to use `!Copy + Reborrow` fields, another would use core marker types
 like `PhantomExclusive<'a>` and `PhantomShared<'b>` to discern the difference.
-
-
 | Task                 | Owner(s) or team(s)                | Notes                                                               |
 |----------------------|------------------------------------|---------------------------------------------------------------------|
 | Lang-team experiment | ![Team][] [lang]                   | allows coding pre-RFC; only for trusted contributors                |

--- a/src/2025h2/build-std.md
+++ b/src/2025h2/build-std.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @davidtwco                         |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#274] |

--- a/src/2025h2/cargo-build-analysis.md
+++ b/src/2025h2/cargo-build-analysis.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @weihanglo                                                                            |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A                                                                              |
-
 ## Summary
 
 Prototype support for build analysis in Cargo by recording build metadata across invocations.

--- a/src/2025h2/cargo-build-dir-layout.md
+++ b/src/2025h2/cargo-build-dir-layout.md
@@ -3,17 +3,12 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @ranger-ross                                                                     |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Rework the Cargo build directory layout to have smaller self contained "units"
-
-
 ## Motivation
 
 Reworking the build directory layout into units will allow us to work to greater Cargo goals.
@@ -62,16 +57,12 @@ A new "user wide" cache is created as a first class solution for sharing build c
 The cache lookup will be extended with plugins to read and/or write to different sources. Open source projects and companies can have their CI read from and write to their cache. Individuals who trust the CI can then configure their plugin to read from the CI cache.
 
 A cooperating CI service could provide their own plugin that, instead of caching everything used in the last job and unpacking it in the next, their plugin could download only the entries that will be needed for the current build (e.g. say a dependency changed) and only upload the cache entries that were freshly built. Fine grain caching like this would save the CI service on bandwidth, storage, and the compute time from copying, decompressing, and compressing the cache. Users would have faster CI time and save money on their CI service, minus any induced demand that faster builds creates.
-
-
 ## Ownership and team asks
 
 | Task                         | Owner(s) or team(s) | Notes |
 |------------------------------|---------------------|-------|
 | Standard reviews             | ![Team][] [cargo]   |       |
 | Implementation               | @ranger-ross        |       |
-
-
 ### Definitions
 
 For definitions for terms used above, see the [About > Team Asks](https://rust-lang.github.io/rust-project-goals/about/team_asks.html) page.

--- a/src/2025h2/cargo-plumbing.md
+++ b/src/2025h2/cargo-plumbing.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed for mentorship            |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#264] |

--- a/src/2025h2/cargo-script.md
+++ b/src/2025h2/cargo-script.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @epage                                                                           |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#119]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Stabilize support for "cargo script", the ability to have a single file that contains both Rust code and a `Cargo.toml`.

--- a/src/2025h2/cargo-semver-checks.md
+++ b/src/2025h2/cargo-semver-checks.md
@@ -3,13 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @obi1kenobi                        |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Proposed                           |
 | Tracking issue   | [rust-lang/rust-project-goals#104] |
 | Zulip channel    | N/A                                |
-
-
 ## Summary
 
 Design and implement `cargo-semver-checks` functionality that lies on the critical path for merging the tool into cargo itself. Continues the work of [the 2025h1 goal][2025h1-goal].

--- a/src/2025h2/codegen_retags.md
+++ b/src/2025h2/codegen_retags.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @icmccorm                                                                        |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A                                                                              |
-
 ## Summary
 Allow codegen backends to implement the MIR [`Retag`](https://doc.rust-lang.org/std/intrinsics/mir/fn.Retag.html) intrinsic, and add a similar intrinsic to the LLVM backend. 
 

--- a/src/2025h2/comprehensive-niche-checks.md
+++ b/src/2025h2/comprehensive-niche-checks.md
@@ -3,9 +3,7 @@
 | Metadata           |                                                                                                                                                                      |
 | :------------------| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Point of contact   | @1c3t3a                                                                                                                                 |
-| Teams              | <!-- TEAMS WITH ASKS -->                                                                                                                                                      |
 | Status             | Proposed                                                                                                                                                             |
-| Task owners        | <!-- TASK OWNERS -->                                                                                     |
 | Tracking issue     | [rust-lang/rust-project-goals#262]                                                                                                                                   |
 | Zulip channel      | https://rust-lang.zulipchat.com/#narrow/channel/435869-project-goals/topic/Null.20and.20enum-discriminant.20runtime.20checks.20in.20.28goals.23262.29/with/508256920 |
 

--- a/src/2025h2/const-generics.md
+++ b/src/2025h2/const-generics.md
@@ -3,12 +3,9 @@
 | Metadata         |             |
 |:-----------------|-------------|
 | Point of contact | @BoxyUwU    |
-| Teams            | <!-- TEAMS WITH ASKS -->        |
-| Task owners      | <!-- TASK OWNERS -->    |
 | Status           | Proposed    |
 | Tracking issue   |             |
 | Zulip channel    | N/A         |
-
 ## Summary
 
 Work towards stabilizing the remaining const generics functionality that was left out of the original `min_const_generics` feature.

--- a/src/2025h2/delegation.md
+++ b/src/2025h2/delegation.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @petrochenkov                      |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust#118212]            |

--- a/src/2025h2/ergonomic-rc.md
+++ b/src/2025h2/ergonomic-rc.md
@@ -3,12 +3,9 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @nikomatsakis                      |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Proposed                           |
 | Tracking issue   | [rust-lang/rust-project-goals#107] |
 | Zulip channel    | N/A                                |
-
 ## Summary
 
 We propose to write an alternative RFC for ergonomic ref-counting that makes lightweight cloning automatic and hold design meetings so the lang team can compare both approaches. This work builds on RFC #3680, which proposed a new keyword, `use`, that could be used with closures (`use || ...`) and expressions like `x.use` to help address a longstanding problem: working with ref-counted data structures like `Arc<T>` is verbose and confusing.
@@ -209,4 +206,3 @@ Once the lang team chooses a direction, subsequent work can focus on refinement,
 ### What is the relationship to the 2025H1 ergonomic ref-counting goal?
 
 This goal builds on the 2025H1 implementation work and the feedback from the RFC. The current implementation already includes most of the infrastructure needed for both approaches - the remaining technical work is primarily about completing the seamless integration option.
-

--- a/src/2025h2/evolving-traits.md
+++ b/src/2025h2/evolving-traits.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @cramertj                                                                        |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    |                                                                                  |
-
 ## Summary
 
 Unblock the evolution of key trait hierarchies:
@@ -82,8 +79,6 @@ pub trait Iterator {
 #### Missing or misnamed parent trait items
 
 Note that, unlike `Deref` and `Receiver`, the names and signatures of the associated items in `LendingIterator` do not match those in `Iterator`. For existing `Iterator` types to implement `LendingIterator`, some bridge code between the two implementations must exist.
-
-
 ### Conceptual supertrait: relaxed bounds
 
 A common practice in the `async` world is to use [the `trait_variant` crate](https://docs.rs/trait-variant/latest/trait_variant/) to make two versions of a trait, one with `Send` bounds on the futures, and one without:

--- a/src/2025h2/field-projections.md
+++ b/src/2025h2/field-projections.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @BennoLossin                                                                     |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A                                                                              |
-
 ## Summary
 
 Figure out the best design for field projections. Update the existing [Field Projections RFC] or
@@ -103,7 +100,4 @@ Have field projections available in stable Rust.
 | Lang-team champion   | ![Team][] [lang]                    | *Champion Needed*                                                   |
 | RFC secondary review | ![Team][] [types]                   | might be a good idea?                                               |
 | RFC decision         | ![Team][] [lang]                    |                                                                     |
-
-
 ## Frequently asked questions
-

--- a/src/2025h2/finishing-gpu-offload.md
+++ b/src/2025h2/finishing-gpu-offload.md
@@ -3,8 +3,6 @@
 | Metadata              |                                                  |
 | :-------------------- | -------------------------------------------------|
 | Point of contact      | @ZuseZ4                                          |
-| Teams                 | <!-- TEAMS WITH ASKS -->                         |
-| Task owners           | <!-- TASK OWNERS -->                             |
 | Status                | Proposed                                         |
 | Tracking issue        | [rust-lang/rust-project-goals#109]               |
 | Other tracking issues | [rust-lang/rust#124509]                          |
@@ -50,8 +48,6 @@ to clean up autodiff docs and finish the upstreaming of `std::batching`, which i
 
 In the future, developers will be able to write a single Rust function and use `std::batching` to get a SIMD/fused version of it, use `std::autodiff` to differentiate it, and `std::offload` to run the resulting code on their GPUs.
 Authors of Machine Learning or Linear Algebra libraries will further be able to optimize their libraries performance by opting into a new MLIR based compiler backend, which automatically rewrites their compute heavy operations for better performance.
-
-
 ## Ownership and team asks
 
 | Task                 | Owner(s) or team(s)                              | Notes                                                                                                                                |
@@ -62,4 +58,3 @@ Authors of Machine Learning or Linear Algebra libraries will further be able to 
 | LLVM reviews         | LLVM offload/GPU contributors                    | Individual contributors at AMD/NVIDIA/LLNL agreed to review my code from the LLVM or GPU side                                        |
 | Do the work          | @ZuseZ4                                          |                                                                                                                                      |
 ## Frequently asked questions
-

--- a/src/2025h2/gcc-backend-tests.md
+++ b/src/2025h2/gcc-backend-tests.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                |
 |:-----------------|------------------------------------------------|
 | Point of contact | @GuillaumeGomez                                |
-| Teams            | <!-- TEAMS WITH ASKS -->                       |
-| Task owners      | <!-- TASK OWNERS -->                           |
 | Status           | Proposed                                       |
 | Tracking issue   | [rust-lang/compiler-team#891]                  |
 | Zulip channel    | [#rustc-codegen-gcc][rustc-codegen-gcc]        |
-
 [rustc-codegen-gcc]: https://rust-lang.zulipchat.com/#narrow/channel/386786-rustc-codegen-gcc
 [rust-lang/compiler-team#891]: https://github.com/rust-lang/compiler-team/issues/891
 
@@ -87,6 +84,4 @@ For definitions for terms used above, see the [About > Team Asks](https://rust-l
     * Library [API Change Proposal (ACP)](https://std-dev-guide.rust-lang.org/development/feature-lifecycle.html) describes a change to the standard library.
 
 ## Frequently asked questions
-
-
 [extra tests]: https://github.com/rust-lang/rustc_codegen_gcc/tree/master/tests/run

--- a/src/2025h2/goals.md
+++ b/src/2025h2/goals.md
@@ -1,5 +1,5 @@
 # Goals
-This page lists the <!-- #GOALS --> project goals **proposed** for 2025h2.
+This page lists the (((#GOALS))) project goals **proposed** for 2025h2.
 
 > Just because a goal is listed on this list does not mean the goal has been accepted.
 > The owner of the goal process makes the final decisions on which goals to include
@@ -9,7 +9,7 @@ This page lists the <!-- #GOALS --> project goals **proposed** for 2025h2.
 
 Flagship goals represent the goals expected to have the broadest overall impact. 
 
-<!-- FLAGSHIP GOALS -->
+(((FLAGSHIP GOALS)))
 
 ## Other goals
 
@@ -17,4 +17,4 @@ These are the other proposed goals.
 
 **Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as a point of contact. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- OTHER GOALS -->
+(((OTHER GOALS)))

--- a/src/2025h2/goals.md
+++ b/src/2025h2/goals.md
@@ -1,6 +1,4 @@
 # Goals
-
-
 This page lists the <!-- #GOALS --> project goals **proposed** for 2025h2.
 
 > Just because a goal is listed on this list does not mean the goal has been accepted.

--- a/src/2025h2/in-place-initialization.md
+++ b/src/2025h2/in-place-initialization.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @Darksonn                                                                        |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | [#t-lang][channel]                                                               |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang
 
 ## Summary
@@ -148,4 +145,3 @@ scheduled.
 | Contribute to the RFC        | @cramertj, @yoshuawuyts, @BennoLossin, @nbdd0121 |       |
 | Lang-team liason             | @joshtriplett                         |       |
 | Dedicated reviewer           | @compiler-errors                      | Of lang experiments |
-

--- a/src/2025h2/interop-problem-map.md
+++ b/src/2025h2/interop-problem-map.md
@@ -3,12 +3,9 @@
 | Metadata         |                           |
 |:-----------------|---------------------------|
 | Point of contact | @baumanj                  |
-| Teams            | <!-- TEAMS WITH ASKS -->  |
-| Task owners      | <!-- TASK OWNERS -->      |
 | Status           | Proposed                  |
 | Tracking issue   |                           |
 | Zulip channel    | [t-lang/interop](https://rust-lang.zulipchat.com/#narrow/channel/427678-t-lang.2Finterop)            |
-
 ## Summary
 
 Document a set of technical issues related to C++/Rust interoperability with broad community consensus to serve as a starting point for proposed solutions and facilitating cooperation among stakeholders in both language communities.

--- a/src/2025h2/libtest-json.md
+++ b/src/2025h2/libtest-json.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#255] |

--- a/src/2025h2/mir-move-elimination.md
+++ b/src/2025h2/mir-move-elimination.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @Amanieu                                                                         |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                             |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Add a MIR optimization which eliminates move operations. This will require changes to the MIR semantics of `move` to enable the optimization to cases where a value has had its address taken (LLVM already eliminates moves when this is not the case).

--- a/src/2025h2/next-solver.md
+++ b/src/2025h2/next-solver.md
@@ -3,15 +3,10 @@
 | Metadata         |                                           |
 |:-----------------|-------------------------------------------|
 | Point of contact | @lcnr                                     |
-| Teams            | <!-- TEAMS WITH ASKS -->                  |
-| Task owners      | <!-- TASK OWNERS -->                      |
 | Status           | Proposed                                  |
 | Tracking issue   | [rust-lang/rust-project-goals#113]        |
 | Zulip channel    | [#t-types/trait-system-refactor][channel] |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor
-
-
 ## Summary
 
 Continue work towards the stabilization of `-Znext-solver=globally`, collecting and resolving remaining blockers. Extend its use in lints and rustdoc.

--- a/src/2025h2/not_accepted.md
+++ b/src/2025h2/not_accepted.md
@@ -1,4 +1,4 @@
 # Not accepted
 This section contains goals that were proposed but ultimately not accepted, either for want of resources or consensus. In many cases, narrower versions of these goals were proposed instead.
 
-<!-- GOALS NOT ACCEPTED -->
+(((GOALS NOT ACCEPTED)))

--- a/src/2025h2/not_accepted.md
+++ b/src/2025h2/not_accepted.md
@@ -1,6 +1,4 @@
 # Not accepted
-
-
 This section contains goals that were proposed but ultimately not accepted, either for want of resources or consensus. In many cases, narrower versions of these goals were proposed instead.
 
 <!-- GOALS NOT ACCEPTED -->

--- a/src/2025h2/open-namespaces.md
+++ b/src/2025h2/open-namespaces.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed for mentorship                            |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#256] |

--- a/src/2025h2/parallel-front-end.md
+++ b/src/2025h2/parallel-front-end.md
@@ -3,16 +3,12 @@
 | Metadata         |                                                   |
 | :--------------- | ------------------------------------------------- |
 | Point of contact | @SparrowLii                                       |
-| Teams            | <!-- TEAMS WITH ASKS -->                          |
-| Task owners      | <!-- TASK OWNERS -->                              |
 | Status           | Proposed                                          |
 | Tracking issue   | [rust-lang/rust-project-goals#121]                |
 | See also         | [rust-lang/rust#113349]                           |
 | Zulip channel    | [#t-compiler/wg-parallel-rustc][channel]          |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fwg-parallel-rustc/
-
-
 ## Summary
 
 Continue with stabilization and performance improvements to parallel front-end, continuing from the [2025h1 goal](https://rust-lang.github.io/rust-project-goals/2025h1/parallel-front-end.html).
@@ -69,8 +65,6 @@ The parallel front end should be:
 | Discussion and moral support | ![Team][] [compiler] |       |
 
 ## Frequently asked questions
-
-
 [ICE]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AWG-compiler-parallel+ice
 [deadlock]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AWG-compiler-parallel+deadlock
 [test]: https://github.com/rust-lang/rust/issues/118698

--- a/src/2025h2/pin-ergonomics.md
+++ b/src/2025h2/pin-ergonomics.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @frank-king                                                                      |
-| Task owners      | <!-- TASK OWNERS -->       |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
 | Status           | Proposed                                                                         |
 | Tracking issue   |      |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Continue experimenting with and fleshing out the design and semantics for the pin ergonomics experiment.
@@ -33,8 +30,6 @@ We have an experiment for improving the ergonomics around pinning and some initi
 - support auto borrowing of `&pin mut|const place` in method calls with `&pin mut|const self` receivers
 
 ### The "shiny future" we are working towards
-
-
 ## Design axioms
 
 ## Ownership and team asks

--- a/src/2025h2/polonius.md
+++ b/src/2025h2/polonius.md
@@ -3,15 +3,10 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @lqd                               |
-| Teams            | <!-- TEAMS WITH ASKS -->           |
-| Task owners      | <!-- TASK OWNERS -->               |
 | Status           | Proposed                           |
 | Tracking issue   | [rust-lang/rust-project-goals#118] |
 | Zulip channel    | [#t-types/polonius][channel]       |
-
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/186049-t-types.2Fpolonius
-
-
 ## Summary
 
 Make a stabilizable version of the [polonius][pc3] next generation borrow checking "alpha" algorithm. This [revision of the analysis][alpha], while less powerful than we hoped, currently scales better than the previous [datalog] implementation, and accepts the main problem case we deferred from NLLs: it handles almost all our in-tree tests, passes perf runs (but is still too slow) and crater runs without issues. It's therefore a worthwhile step to ship to users, but needs more work to be properly usable on nightly.

--- a/src/2025h2/production-ready-cranelift.md
+++ b/src/2025h2/production-ready-cranelift.md
@@ -3,8 +3,6 @@
 | Metadata         |                          |
 | :--------------- | ------------------------ |
 | Point of contact | @folkertdev              |
-| Teams            | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS -->     |
 | Status           | Proposed                 |
 | Tracking issue   |                          |
 | Zulip channel    |                          |

--- a/src/2025h2/pub-priv.md
+++ b/src/2025h2/pub-priv.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @epage                             |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed for mentorship            |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#272] |

--- a/src/2025h2/reference-expansion.md
+++ b/src/2025h2/reference-expansion.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @joshtriplett                      |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed                           |
 | Zulip channel      | [#t-spec][channel]                 |
 | Tracking issue     |                                    |

--- a/src/2025h2/reflection-and-comptime.md
+++ b/src/2025h2/reflection-and-comptime.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @oli-obk                                                                         |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Status           | Proposed                                                                         |
 | Other Tracking issue   | [rust-lang/rust#142577]                                  |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 Design, implement and experimentally land a reflection scheme based on `const fn` that can only be called at compile time.
@@ -124,8 +121,6 @@ an demonstration impl (absolutely not salvageable for anything that could be lan
 ### Why not continue where uwuflection left off?
 
 See https://soasis.org/posts/a-mirror-for-rust-a-plan-for-generic-compile-time-introspection-in-rust/ for details on what uwuflection is
-
-
 #### Structural processing
 
 it makes procedural processing of type information very hard. E.g. to get the 3rd element of a tuple you need to 

--- a/src/2025h2/relink-dont-rebuild.md
+++ b/src/2025h2/relink-dont-rebuild.md
@@ -1,11 +1,7 @@
 # Relink don't Rebuild
-
-
 | Metadata         |                        |
 | --------         | ---                    |
 | Point of contact | @yaahc                 |
-| Teams            | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS -->   |
 | Status           | Proposed               |
 | Tracking issue   | |
 | Zulip channel    | |
@@ -96,8 +92,6 @@ such a change was made to `globset`:
 <p align="center">
   <img src="https://raw.githubusercontent.com/wiki/rrbutani/rust/rdr-cargo-timings-output.png" />
 </p>
-
-
 In the above we see `globset` and all transitive "upstream" dependent crates (up to `ripgrep`)
 being rebuilt.
 

--- a/src/2025h2/rust-vision-doc.md
+++ b/src/2025h2/rust-vision-doc.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @nikomatsakis                      |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed                           |
 | Zulip channel      | [#vision-doc-2025][channel]        |
 | Tracking issue     | [rust-lang/rust-project-goals#269] |

--- a/src/2025h2/rustc-perf-improvements.md
+++ b/src/2025h2/rustc-perf-improvements.md
@@ -3,8 +3,6 @@
 | Metadata           |                                                          |
 | :--                | :--                                                      |
 | Point of contact   | @Jamesbarford                                            |
-| Teams              | <!-- TEAMS WITH ASKS -->                                 |
-| Task owners        | <!-- TASK OWNERS -->                                     |
 | Status             | Proposed                                                 |
 | Zulip channel      | [#project-goals/2025h1/rustc-perf-improvements][channel] |
 | Tracking issue     | [rust-lang/rust-project-goals#275]                       |

--- a/src/2025h2/rustdoc-doc-cfg.md
+++ b/src/2025h2/rustdoc-doc-cfg.md
@@ -3,12 +3,9 @@
 | Metadata         |                                                |
 |:-----------------|------------------------------------------------|
 | Point of contact | @GuillaumeGomez                                |
-| Teams            | <!-- TEAMS WITH ASKS -->                       |
-| Task owners      | <!-- TASK OWNERS -->                           |
 | Status           | Proposed                                       |
 | Tracking issue   | [rust-lang/rust#43781]                         |
 | Zulip channel    | [#t-rustdoc][t-rustdoc]                        |
-
 [t-rustdoc]: https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc
 
 ## Summary

--- a/src/2025h2/rustdoc-team-charter.md
+++ b/src/2025h2/rustdoc-team-charter.md
@@ -3,12 +3,8 @@
 | Metadata         |                                                |
 |:-----------------|------------------------------------------------|
 | Point of contact | @GuillaumeGomez                                |
-| Teams            | <!-- TEAMS WITH ASKS -->                       |
-| Task owners      | <!-- TASK OWNERS -->                           |
 | Status           | Proposed                                       |
 | Zulip channel    | [#t-rustdoc](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc)                        |
-
-
 ## Summary
 
 Over the next six months, we will do the following:

--- a/src/2025h2/scalable-vectors.md
+++ b/src/2025h2/scalable-vectors.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @davidtwco                         |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#270] |

--- a/src/2025h2/stabilization-of-sanitizer-support.md
+++ b/src/2025h2/stabilization-of-sanitizer-support.md
@@ -3,9 +3,7 @@
 | Metadata         |                                                                                  |
 | :--------------- | :------------------------------------------------------------------------------- |
 | Point of contact | @jakos-sec                                                                       |
-| Teams            | <!-- TEAMS WITH ASKS -->                                                         |
 | Status           | Proposed                                                                         |
-| Task owners      | <!-- TASK OWNERS -->                                                             |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A                                                                              |
 

--- a/src/2025h2/typesystem-docs.md
+++ b/src/2025h2/typesystem-docs.md
@@ -3,12 +3,9 @@
 | Metadata         |          |
 |:-----------------|----------|
 | Point of contact | @BoxyUwU |
-| Teams            | <!-- TEAMS WITH ASKS --> |
-| Task owners      | <!-- TASK OWNERS --> |
 | Status           | Proposed |
 | Tracking issue   |          |
 | Zulip channel    | N/A      |
-
 ## Summary
 
 Improve documentation of type system components to aide in types team onboarding and communication about changes to the type system .

--- a/src/2025h2/unsafe-fields.md
+++ b/src/2025h2/unsafe-fields.md
@@ -3,8 +3,6 @@
 | Metadata           |                                    |
 | :--                | :--                                |
 | Point of contact   | @jswrenn                           |
-| Teams              | <!-- TEAMS WITH ASKS -->           |
-| Task owners        | <!-- TASK OWNERS -->               |
 | Status             | Proposed                           |
 | Zulip channel      | N/A                                |
 | Tracking issue     | [rust-lang/rust-project-goals#273] |

--- a/src/README.md
+++ b/src/README.md
@@ -21,8 +21,6 @@ The 2025H1 goal period runs from Jan 1 to Jun 30. We have identified three flags
     * author a first draft for a [Rust vision doc](./rust-vision-doc.md) and gather feedback.
 
 [The full list of 2025H1 goals is available here.](./2025h1/goals.md) We author monthly blog posts about our overall status, but you can also follow the tracking issue for a [particular goal](./2025h1/goals.md) to get updates specific to that goal.
-
-
 ## Next goal period (2025H2)
 
 The next goal period will be 2025H2, running from July 1 to December 30. We are currently in the process of assembling goals. [Click here](./2025h2/goals.md) to see the current list. If you'd like to propose a goal, [instructions can be found here](./how_to/propose_a_goal.md).

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -17,7 +17,6 @@
 | Status           | Proposed                                                                         |
 | Tracking issue   | *if this is a continuing goal, add the old tracking issue, else leave blank*     |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
-
 ## Summary
 
 *Short description of what you will do over the next 6 months.*

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -19,7 +19,6 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | *must be a single Github username like @ghost*                                   |
-| Teams            | &lt;!-- TEAMS WITH ASKS --&gt;                                                   |
 | Task owners      | &lt;!-- TASK OWNERS --&gt;                                                       |
 | Status           | Proposed                                                                         |
 | Tracking issue   | *if this is a continuing goal, add the old tracking issue, else leave blank*     |

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -10,16 +10,10 @@
 >
 > The **status** should be either **Proposed** (if you have owners)
 > or **Proposed, Invited** (if you do not yet).
->
-> Note that the **Teams** and **Task owners** rows use special values that can look different if
-> you're copying this template from the markdown source or the project goals website. In the
-> markdown source, they are encoded to show up on the website, but make sure to use raw `<!--` and
-> `-->`.
 
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | *must be a single Github username like @ghost*                                   |
-| Task owners      | &lt;!-- TASK OWNERS --&gt;                                                       |
 | Status           | Proposed                                                                         |
 | Tracking issue   | *if this is a continuing goal, add the old tracking issue, else leave blank*     |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |

--- a/src/about/motivation.md
+++ b/src/about/motivation.md
@@ -14,4 +14,3 @@ It should answer the following questions
 The **next few steps** can explain how you plan to change that and why these are the right next steps to take.
 
 Finally, the **shiny future** section can put the goal into a longer term context. It's ok if the goal doesn't have a shiny future beyond the next few steps.
-

--- a/src/about/team_asks.md
+++ b/src/about/team_asks.md
@@ -8,4 +8,4 @@ The list of recognized asks is shown below:
 * The *aka* column is a shorter name for the ask used in the condensed RFC tables.
 * The *description* column describes what you are asking for.
 
-<!-- VALID TEAM ASKS -->
+(((VALID TEAM ASKS)))

--- a/src/admin/reference.md
+++ b/src/admin/reference.md
@@ -1,2 +1,1 @@
 # Technical reference
-

--- a/src/admin/running-the-program.md
+++ b/src/admin/running-the-program.md
@@ -27,8 +27,6 @@ Each of the calendars has someoverlap with the previous and next previous.
 | [RFC]     |                           | ███ |                 |                      |
 | [Updates] |                           |     | ███████████████ |                      |
 | [Retro]   |                           |     |                 | ███                  |
-
-
 [CFP]: ./cfp.md
 [RFC]: ./prepare_rfc.md
 [Updates]: ./author_updates.md

--- a/src/admin/samples/goals.md
+++ b/src/admin/samples/goals.md
@@ -4,7 +4,7 @@
 >
 > * Search and replace `YYYYHN` with `2222H1` and delete this section.
 
-This page lists the <!-- #GOALS --> project goals **proposed** for YYYYHN.
+This page lists the (((#GOALS))) project goals **proposed** for YYYYHN.
 
 > Just because a goal is listed on this list does not mean the goal has been accepted.
 > The owner of the goal process makes the final decisions on which goals to include
@@ -14,7 +14,7 @@ This page lists the <!-- #GOALS --> project goals **proposed** for YYYYHN.
 
 Flagship goals represent the goals expected to have the broadest overall impact. 
 
-<!-- FLAGSHIP GOALS -->
+(((FLAGSHIP GOALS)))
 
 ## Other goals
 
@@ -22,4 +22,4 @@ These are the other proposed goals.
 
 **Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as a point of contact. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- OTHER GOALS -->
+(((OTHER GOALS)))

--- a/src/admin/samples/not_accepted.md
+++ b/src/admin/samples/not_accepted.md
@@ -4,4 +4,4 @@
 
 This section contains goals that were proposed but ultimately not accepted, either for want of resources or consensus. In many cases, narrower versions of these goals were proposed instead.
 
-<!-- GOALS NOT ACCEPTED -->
+(((GOALS NOT ACCEPTED)))

--- a/src/admin/samples/rfc.md
+++ b/src/admin/samples/rfc.md
@@ -16,7 +16,7 @@ This is a draft for the eventual RFC proposing the YYYYHN goals.
 
 ## Motivation
 
-The YYYYHN goal slate consists of <!-- #GOALS --> project goals, of which we have selected (TBD) as **flagship goals**. Flagship goals represent the goals expected to have the broadest overall impact.
+The YYYYHN goal slate consists of (((#GOALS))) project goals, of which we have selected (TBD) as **flagship goals**. Flagship goals represent the goals expected to have the broadest overall impact.
 
 ### How the goal process works
 
@@ -63,7 +63,7 @@ The full slate of project goals are as follows. These goals all have identified 
 
 **Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as a point of contact. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
 
-<!-- GOALS -->
+(((GOALS)))
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -71,7 +71,7 @@ The full slate of project goals are as follows. These goals all have identified 
 The following table highlights the asks from each affected team.
 The "owner" in the column is the person expecting to do the design/implementation work that the team will be approving.
 
-<!-- TEAM ASKS -->
+(((TEAM ASKS)))
 
 ### Definitions
 

--- a/src/admin/setup.md
+++ b/src/admin/setup.md
@@ -17,4 +17,3 @@ The rust-project-goals repository is set up as follows
         * *N* is a threshold number of days; if people have posted an update within the last N days, we won't bother them. Usually I do this as the current date + 7, so that people who posted during the current month or the last week of the previous month don't get any pings.
         * *D* is a word like `Sep-22` that indicates the day
     * the bot monitors for comments on github and forwards them to Zulip
-

--- a/src/admin/updates.md
+++ b/src/admin/updates.md
@@ -13,8 +13,6 @@ The template will be filled in with the list of flagship goals. Each flagship go
 The template will also include the detailed list of updates in a `<details>` section as well as any TL;DR comments left by users.
 
 The update template itself is maintained with handlebars, you will find it [here](https://github.com/rust-lang/rust-project-goals/blob/main/templates/updates.hbs).
-
-
 This command can also take optional dates to control which comments and updates in the given date range are included in the blog post. This is usually needed to correctly set the starting date right after the previous month's blog post.
 
 For example,


### PR DESCRIPTION
The use of HTML comments was causing issues. This eliminates unnecessary placeholders and replaces others with `(((...)))`. Also modifies how flagship goals work to support themes (we'll be using this in 2025H2).

cc @lqd @tomassedovic 

[Rendered](https://github.com/nikomatsakis/rust-project-goals-ndm/blob/main/src/2024h2/Contracts-and-invariants.md)