### PR TITLE
Codegen Retags: fix GH username 

### DIFF
--- a/src/2025h2/codegen_retags.md
+++ b/src/2025h2/codegen_retags.md
@@ -6,9 +6,9 @@
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A                                                                              |
-| [compiler] champion | @RalfJ |
+| [compiler] champion | @RalfJung |
 | [lang] champion | @tmandry |
-| [opsem] champion | @RalfJ |
+| [opsem] champion | @RalfJung |
 
 ## Summary
 Allow codegen backends to implement the MIR [`Retag`](https://doc.rust-lang.org/std/intrinsics/mir/fn.Retag.html) intrinsic, and add a similar intrinsic to the LLVM backend. 


### PR DESCRIPTION
Fixes two remaining references intended to be @RalfJung (see #362).

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2025h2/codegen_retags.md)