### PR TITLE
Update onig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,11 +1503,11 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "onig"
-version = "6.4.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1515,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
Running any `cargo rpg` command locally fails with:

```
$ cargo rpg issues ./src/2025h2/
error: failed to run custom build command for `onig_sys v69.8.1`
[...] 
   cargo:warning=oniguruma/src/regparse.c: In function ‘onig_st_init_strend_table_with_size’:
  cargo:warning=oniguruma/src/regparse.c:588:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_str_end_key *, st_str_end_key *)’ [-Wincompatible-pointer-types]
  cargo:warning=  588 |     str_end_cmp,
  cargo:warning=      |     ^~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:588:5: note: (near initialization for ‘hashType.compare’)
  cargo:warning=oniguruma/src/regparse.c:550:1: note: ‘str_end_cmp’ declared here
  cargo:warning=  550 | str_end_cmp(st_str_end_key* x, st_str_end_key* y)
  cargo:warning=      | ^~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:589:5: error: initialization of ‘int (*)(void)’ from incompatible pointer type ‘int (*)(st_str_end_key *)’ [-Wincompatible-pointer-types]
  cargo:warning=  589 |     str_end_hash,
  cargo:warning=      |     ^~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:589:5: note: (near initialization for ‘hashType.hash’)
  cargo:warning=oniguruma/src/regparse.c:571:1: note: ‘str_end_hash’ declared here
  cargo:warning=  571 | str_end_hash(st_str_end_key* x)
  cargo:warning=      | ^~~~~~~~~~~~```
[...] lots of skipped output
```

Updating to the latest `onig` version (via `cargo update onig`) fixes this.