### PR TITLE
make monthly reports manual

### DIFF
--- a/src/2025h2/reports.md
+++ b/src/2025h2/reports.md
@@ -1,3 +1,3 @@
 # Reports
 
-(((REPORTS)))
+(((REPORTS: 2025-09-01 to 2025-10-31)))


### PR DESCRIPTION
Automatic monthly reports are broken, the previous month disappears immediately as the month ends. Until it's fixed, constrain the range manually to keep old ones, and avoid generation of ones in the future.

I'll cc @nikomatsakis for awareness but will merge to unblock people.