### PR TITLE
filter out hidden comments from reports

### DIFF
--- a/crates/rust-project-goals-cli/src/updates.rs
+++ b/crates/rust-project-goals-cli/src/updates.rs
@@ -231,7 +231,8 @@ fn prepare_goals(
 
         let mut comments = issue.comments.clone();
         comments.sort_by_key(|c| c.created_at.clone());
-        comments.retain(|c| !c.is_automated_comment() && filter.matches(c));
+        comments.retain(|c| !c.should_hide_from_reports() && filter.matches(c));
+
         // Prettify the comments' timestamp after using it for sorting.
         for comment in comments.iter_mut() {
             comment.created_at = format!("{}", comment.created_at_date());


### PR DESCRIPTION
Automated comments are filtered from reports, so we don't see e.g. https://github.com/rust-lang/rust-project-goals/issues/270#issuecomment-3299926998 from this goal report.

However, other comments such as https://github.com/rust-lang/rust-project-goals/issues/270#issuecomment-3299916459 were hidden as outdated but will still be present in the report, as can currently be seen [here](https://rust-lang.github.io/rust-project-goals/lang/2025-09.html) for the SVE goal. 

This PR filters out the GH comments marked as hidden in general, so that the goal owners or person generating the monthly report can remove the comments that were taken care of already, or outdated or unrelated comments from the reports, instead of how we've been doing it usually, manually deleting them from the generated markdown. This is useful now with the new idea of the reports and blog posts being live documents where this strategy doesn't work anymore.

