### PR TITLE
Expose reqwest's inner error in the `fetch` function

### DIFF
--- a/crates/rust-project-goals/src/team.rs
+++ b/crates/rust-project-goals/src/team.rs
@@ -128,8 +128,8 @@ where
             e.source()
                 .map(|json_error| spanned::Error::str(json_error.to_string()))
                 .unwrap_or(e.into())
-        });
+        })?;
 
-        Ok(json_response?)
+        Ok(json_response)
     })
 }


### PR DESCRIPTION
We were converting the `reqwest::Error` type directly to `span::Error` and the rendering chain stopped at that. This ignored the inner (source) error which contained the most useful information to figure out what went wrong.

This gets us from:

    Error: error: failed to fetch: error: error decoding response body

to:

    Error: error: failed to fetch: error: error decoding response body: missing field `discord` at line 16049 column 1