### PR TITLE
Format with `cargo fmt`

### DIFF
--- a/crates/mdbook-goals/src/mdbook_preprocessor.rs
+++ b/crates/mdbook-goals/src/mdbook_preprocessor.rs
@@ -309,7 +309,10 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         let mut old_format_asks: Vec<&TeamAsk> = vec![];
         let mut new_format_goals: Vec<&GoalDocument> = vec![];
 
-        for goal in goals.iter().filter(|g| g.metadata.status.is_not_not_accepted()) {
+        for goal in goals
+            .iter()
+            .filter(|g| g.metadata.status.is_not_not_accepted())
+        {
             match &goal.team_involvement {
                 TeamInvolvement::Asks(asks) => {
                     old_format_asks.extend(asks.iter());
@@ -324,9 +327,8 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         let mut formatted = String::new();
 
         if !old_format_asks.is_empty() {
-            formatted.push_str(
-                &format_team_asks(&old_format_asks).map_err(|e| anyhow::anyhow!("{e}"))?,
-            );
+            formatted
+                .push_str(&format_team_asks(&old_format_asks).map_err(|e| anyhow::anyhow!("{e}"))?);
         }
 
         if !new_format_goals.is_empty() {
@@ -731,7 +733,7 @@ impl<'c> GoalPreprocessorWithContext<'c> {
             &Some(end_date),
             None,
             false,
-	    Order::OldestFirst,
+            Order::OldestFirst,
         )
         .map_err(|e| anyhow::anyhow!("Failed to generate blog post content: {}", e))?;
 
@@ -743,9 +745,9 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         milestone: &str,
         team_name: &str,
     ) -> anyhow::Result<String> {
-	// Look at the updates for the last ~three months
-	let end_date = chrono::Utc::now().date_naive();
-	let start_date = end_date - chrono::TimeDelta::days(90);
+        // Look at the updates for the last ~three months
+        let end_date = chrono::Utc::now().date_naive();
+        let start_date = end_date - chrono::TimeDelta::days(90);
 
         eprintln!(
             "👥 Generating champion report for {} team, {start_date} - {end_date} (milestone: {})",
@@ -768,7 +770,7 @@ impl<'c> GoalPreprocessorWithContext<'c> {
             &Some(end_date),
             Some(team_name),
             false,
-	    Order::NewestFirst,
+            Order::NewestFirst,
         )
         .map_err(|e| anyhow::anyhow!("Failed to generate champion report content: {}", e))?;
 

--- a/crates/rust-project-goals-cli/src/cfp.rs
+++ b/crates/rust-project-goals-cli/src/cfp.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use rust_project_goals::spanned::{Error, Spanned};
-use rust_project_goals::{spanned::Context as _, spanned::Result};
 use rust_project_goals::util::MILESTONE_REGEX;
+use rust_project_goals::{spanned::Context as _, spanned::Result};
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -575,8 +575,14 @@ mod tests {
         let intro_pos = result.find("[👋 Introduction]").unwrap();
         let goal_process_pos = result.find("# ⏳ 2026H1 goal process").unwrap();
         let existing_section_pos = result.find("# ⚙️ 2025H2").unwrap();
-        assert!(intro_pos < goal_process_pos, "Goal process section should come after Introduction");
-        assert!(goal_process_pos < existing_section_pos, "New section should come before existing dated section");
+        assert!(
+            intro_pos < goal_process_pos,
+            "Goal process section should come after Introduction"
+        );
+        assert!(
+            goal_process_pos < existing_section_pos,
+            "New section should come before existing dated section"
+        );
     }
 
     #[test]
@@ -593,8 +599,14 @@ mod tests {
         let intro_pos = result.find("[👋 Introduction]").unwrap();
         let goal_process_pos = result.find("# ⏳ 2027 goal process").unwrap();
         let existing_section_pos = result.find("# ⚙️ 2025H2").unwrap();
-        assert!(intro_pos < goal_process_pos, "Goal process section should come after Introduction");
-        assert!(goal_process_pos < existing_section_pos, "New section should come before existing dated section");
+        assert!(
+            intro_pos < goal_process_pos,
+            "Goal process section should come after Introduction"
+        );
+        assert!(
+            goal_process_pos < existing_section_pos,
+            "New section should come before existing dated section"
+        );
     }
 
     #[test]

--- a/crates/rust-project-goals-cli/src/lib.rs
+++ b/crates/rust-project-goals-cli/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod updates;
 
-pub use updates::{Order, render_updates};
+pub use updates::{render_updates, Order};

--- a/crates/rust-project-goals-cli/src/main.rs
+++ b/crates/rust-project-goals-cli/src/main.rs
@@ -238,7 +238,7 @@ fn generate_updates(
         end_date,
         with_champion_from,
         true,
-	updates::Order::default(),
+        updates::Order::default(),
     )?;
 
     if let Some(output_file) = output_file {

--- a/crates/rust-project-goals-cli/src/rfc.rs
+++ b/crates/rust-project-goals-cli/src/rfc.rs
@@ -170,9 +170,10 @@ pub fn generate_issues(
             if success == 0 {
                 spanned::bail_here!("all actions failed, aborting")
             }
-            
+
             // Clear the cached issues since we just modified them
-            if let Err(e) = rust_project_goals::gh::issues::clear_milestone_issues_cache(&timeframe) {
+            if let Err(e) = rust_project_goals::gh::issues::clear_milestone_issues_cache(&timeframe)
+            {
                 eprintln!("Warning: Failed to clear issues cache: {}", e);
             }
         } else {

--- a/crates/rust-project-goals-cli/src/updates.rs
+++ b/crates/rust-project-goals-cli/src/updates.rs
@@ -175,7 +175,7 @@ pub fn render_updates(
         &filter,
         true,
         use_progress_bar,
-	comment_order,
+        comment_order,
         &issue_themes,
         &issue_point_of_contact,
         &issue_team_champions,
@@ -187,7 +187,7 @@ pub fn render_updates(
         &filter,
         false,
         use_progress_bar,
-	comment_order,
+        comment_order,
         &issue_themes,
         &issue_point_of_contact,
         &issue_team_champions,
@@ -244,10 +244,10 @@ fn prepare_goals(
         comments.sort_by_key(|c| c.created_at.clone());
         comments.retain(|c| !c.should_hide_from_reports() && filter.matches(c));
 
-	// We got the comments in the chronological order. Reverse it if desired.
-	if matches!(comment_order, Order::NewestFirst) {
+        // We got the comments in the chronological order. Reverse it if desired.
+        if matches!(comment_order, Order::NewestFirst) {
             comments.reverse();
-	}
+        }
 
         // Prettify the comments' timestamp after using it for sorting.
         for comment in comments.iter_mut() {

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -691,9 +691,7 @@ fn extract_team_involvement(
         return Ok((TeamInvolvement::Asks(team_asks), goal_plans, task_owners));
     }
 
-    spanned::bail_here!(
-        "no `Team asks` or `Ownership and team asks` section found"
-    )
+    spanned::bail_here!("no `Team asks` or `Ownership and team asks` section found")
 }
 
 /// Extract team support entries from the new format (2026+).
@@ -827,7 +825,10 @@ impl std::fmt::Display for SupportLevel {
 }
 
 /// Extract plan items from the old format, starting at the given section index.
-fn extract_plan_items_from_index(sections: &[Section], ownership_index: usize) -> Result<Vec<GoalPlan>> {
+fn extract_plan_items_from_index(
+    sections: &[Section],
+    ownership_index: usize,
+) -> Result<Vec<GoalPlan>> {
     // Extract the plan items from the main section (if any)
     let level = sections[ownership_index].level;
 


### PR DESCRIPTION
This adds a new (empty, i.e. relying on defaults) `rustfmt.toml` file and formats the repository with `cargo fmt`.

The changes are very few and most of them seem to do with whitespace handling (we had some tabs sneak into our indentation).