### PR TITLE
Add 2026 goal for Wasm Components

### DIFF
--- a/src/2026/wasm-components.md
+++ b/src/2026/wasm-components.md
@@ -10,7 +10,7 @@
 ## Summary
 
 In 2026 we want to improve the state of Wasm Component support in Rust. This
-means adding and stabilizing three new compiler targets. As well as begin
+means adding and stabilizing three new compiler targets, as well as begin
 experimentation with Wasm-specific language features.
 
 ## Motivation


### PR DESCRIPTION
This adds a 2026 goal to improve support for Wasm Components in Rust. Thanks!

cc/ @alexcrichton, @lukewagner

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/wasm-components.md)