### PR TITLE
Supertrait Auto Impl

### DIFF
--- a/src/2026/supertrait-auto-impl.md
+++ b/src/2026/supertrait-auto-impl.md
@@ -84,7 +84,7 @@ We would like to establish a mechanism in the language to automatically derive t
 | [cargo]    |               |                                         |
 | [compiler] |               |                                         |
 | [infra]    |               |                                         |
-| [lang]     |               |                                         |
+| [lang]     |  Medium | Team aligned already on the shape of the feature |
 | [libs]     |               |                                         |
 | [opsem]    |               |                                         |
 | [types]    |               |                                         |


### PR DESCRIPTION
We are applying a 2026 project goal status for `supertrait_auto_impl` for accelerated development of the language feature as defined in rust-lang/rfcs#3851 as our solution to the trait evolution question.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/supertrait-auto-impl.md)