### PR TITLE
Add 2026 project goal for `super let`

### DIFF
--- a/src/2026/redesigning-super-let.md
+++ b/src/2026/redesigning-super-let.md
@@ -40,7 +40,7 @@ Making it easier to extend the lifetimes of temporaries opens up the possibility
 
 | Team       | Support level    | Notes                                   |
 | ---------- | -------------    | --------------------------------------- |
-| [compiler] | small or medium  | The complexity of compiler changes would depend on how the feature design turns out. |
+| [compiler] | small  | May escalate to medium depending on how the feature design turns out. |
 | [lang]     | large            | Would need a design meeting and RFC review. |
 | [libs]     | vibes or small   | Since `super let` affects the standard library, the library team should be on-board with any new directions it takes. Additionally, library team review may be required for changes to `pin!`'s implementation. Could be "medium" if the library team decides a champion is necessary. |
 


### PR DESCRIPTION
This adds a goal for `super let` (https://github.com/rust-lang/rust/issues/139076), with the aim of sorting out outstanding design questions and working towards stabilization.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/redesigning-super-let.md)