### PR TITLE
Set the date range in the monthly blog posts correctly

### DIFF
--- a/crates/mdbook-goals/src/mdbook_preprocessor.rs
+++ b/crates/mdbook-goals/src/mdbook_preprocessor.rs
@@ -710,6 +710,7 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         // Calculate start and end dates for the month
         let start_date = NaiveDate::from_ymd_opt(year, month, 1)
             .ok_or_else(|| anyhow::anyhow!("Invalid date: {}-{:02}-01", year, month))?;
+        // The `end_date` is an exclusive range, so this will match comments within the given `month`
         let end_date = if month == 12 {
             NaiveDate::from_ymd_opt(year + 1, 1, 1)
         } else {

--- a/crates/rust-project-goals-cli/src/main.rs
+++ b/crates/rust-project-goals-cli/src/main.rs
@@ -79,6 +79,10 @@ enum Command {
 
     /// Generate markdown with the list of updates for each tracking issue.
     /// Collects goal updates.
+    ///
+    /// The start date is inclusive and the end date is exclusive.
+    /// E.g. to generate the blog for the month of July, you'd specify: `2025-07-01 2025-08-01`.
+    /// This would not include the August date.
     Updates {
         /// Milestone for which we generate tracking issue data (e.g., `2024h2`).
         milestone: String,
@@ -92,10 +96,12 @@ enum Command {
         output_file: Option<PathBuf>,
 
         /// Start date for comments.
+        /// This is the first date from which comments will be picked up.
         /// If not given, defaults to 1 week before the start of this month.
         start_date: Option<chrono::NaiveDate>,
 
         /// End date for comments.
+        /// Comments from this day onward will NOT be picked up.
         /// If not given, no end date.
         end_date: Option<chrono::NaiveDate>,
 

--- a/crates/rust-project-goals-cli/src/updates.rs
+++ b/crates/rust-project-goals-cli/src/updates.rs
@@ -394,7 +394,7 @@ impl Filter<'_> {
 
         date >= self.start_date
             && match self.end_date {
-                Some(end_date) => date <= *end_date,
+                Some(end_date) => date < *end_date,
                 None => true,
             }
     }

--- a/src/admin/updates.md
+++ b/src/admin/updates.md
@@ -15,8 +15,8 @@ The template will also include the detailed list of updates in a `<details>` sec
 The update template itself is maintained with handlebars, you will find it [here](https://github.com/rust-lang/rust-project-goals/blob/main/templates/updates.hbs).
 This command can also take optional dates to control which comments and updates in the given date range are included in the blog post. This is usually needed to correctly set the starting date right after the previous month's blog post.
 
-For example,
+The updates on the Rust blog typically cover a single calendar month. Since the start date is inclusive and the end date is exclusive, to generate an update for e.g. March 2025 you'd type:
 
 ```
-> cargo rpg updates 2025h1 2025-03-01
+> cargo rpg updates 2025h1 2025-03-01 2025-04-01
 ```


### PR DESCRIPTION
The monthly pages in the Reports section were using dates ending with the start of the new month (e.g. from: `2025-10-01` to: `2025-11-01` instead of: `2025-10-31`).

This resulted in e.g. comments from the 1st November being included in both the October and November updates.

In addition, that led to the discrepancy of the posts published on the Rust blog as those have the dates set manually (and according to expectations).

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/admin/updates.md)