### PR TITLE
Ergonomic RC: fix the champion label

### DIFF
--- a/src/2026/ergonomic-rc.md
+++ b/src/2026/ergonomic-rc.md
@@ -6,7 +6,7 @@
 | Status            | Proposed                           |
 | Tracking issue    | [rust-lang/rust-project-goals#107] |
 | Zulip channel     | N/A                                |
-| [T-lang] champion | @nikomatsakis                      |
+| [lang] champion   | @nikomatsakis                      |
 
 ## Summary
 


### PR DESCRIPTION
The `Metadata` table had the `[T-lang] champion` section which is unexpected and was failing the mdbook build.

Moving it down to `Team Asks` fixes it.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/ergonomic-rc.md)