### PR TITLE
Update the template to say `Proposed for mentorship` status

### DIFF
--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -9,7 +9,7 @@
 > The **point of contact** is the person responsible for providing updates.
 >
 > The **status** should be either **Proposed** (if you have owners)
-> or **Proposed, Invited** (if you do not yet).
+> or **Proposed for mentorship** (if you do not yet).
 
 | Metadata         |                                                                                  |
 | :--------------- | -------------------------------------------------------------------------------- |


### PR DESCRIPTION
The template has been using `Proposed, Invited` for a status that's not been accepted yet (which `Invited` implies) but that doesn't have an owner set.

However, the tooling did and still does expect `Proposed for mentorship` and as far as I can tell that's definitely been the case for at least the last couple cycles, probably longer.

Right now, we're telling people to use a status that our tooling will reject.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/TEMPLATE.md)