### PR TITLE
Continue the core Rust for Linux goals

### DIFF
--- a/src/2026/Rust-for-Linux-compiler.md
+++ b/src/2026/Rust-for-Linux-compiler.md
@@ -1,0 +1,82 @@
+# Rust for Linux in stable: compiler features
+
+| Metadata            |                                    |
+|:--------------------|------------------------------------|
+| Point of contact    | @tomassedovic                      |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#407] |
+| Zulip channel       | [#rust-for-linux][channel-rfl]     |
+| [compiler] champion | @WesleyWiser                       |
+
+[channel-t-compiler]: https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler
+[channel-rust-for-linux]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux
+
+## Summary
+
+Develop and stabilize compiler features that Rust for Linux uses. This is a continuation of the existing Rust for Linux effort.
+
+## Motivation
+
+Getting the Linux kernel to build with stable Rust and, more generally, supporting the needs of the Linux kernel to make Rust a success there, has been a priority for the Rust project and a previous flagship goal: [2024H2](https://rust-lang.github.io/rust-project-goals/2024h2/rfl_stable.html), [2025H1](https://rust-lang.github.io/rust-project-goals/2025h1/rfl.html).
+
+One of the key areas are compiler features, which encompass a wide range of topics: architecture/target-related flags, sanitizers, mitigations, performance/optimization-oriented flags, and so on.
+
+The primary goal is to offer stable support for the particular use cases that the Linux kernel requires. We're sticking to the **Don't let perfect be the enemy of good** approach.  Wherever possible we aim to stabilize features completely, but if necessary, we can try to stabilize a subset of functionality that meets the kernel developers' needs while leaving other aspects unstable.
+
+
+### The status quo
+
+The Linux kernel, at the time of writing, relies on some Rust compiler unstable features such as:
+
+  - [`-Zbranch-protection`](https://github.com/rust-lang/rust/issues/113369) (arm64).
+  - [`-Zcf-protection`](https://github.com/rust-lang/rust/issues/93754) (x86_64).
+  - [`-Zcrate-attr`](https://github.com/rust-lang/rust/issues/138287).
+  - [`-Zdebuginfo-compression`](https://github.com/rust-lang/rust/issues/120953).
+  - [`-Zdirect-access-external-data`](https://github.com/rust-lang/rust/issues/127488) (loongarch).
+  - `-Zfixed-x18` (arm64).
+  - [`-Zfunction-return`](https://github.com/rust-lang/rust/issues/116853) (x86).
+  - `-Zfunction-sections`.
+  - [`-Zno-jump-tables`](https://github.com/rust-lang/rust/issues/116592) (x86_64).
+  - [`-Zunpretty=expanded`](https://github.com/rust-lang/rust/issues/43364).
+  - [`-Zsanitizer=kernel-address`](https://github.com/rust-lang/rust/issues/123615) (arm64, riscv64).
+  - [`-Zsanitizer=shadow-call-stack`](https://github.com/rust-lang/rust/issues/123615) (arm64, riscv64).
+  - [`-Zsanitizer=kcfi` and `-Zsanitizer-cfi-normalize-integers`](https://github.com/rust-lang/rust/issues/123479) (arm64, riscv64, x86_64).
+
+There are others that we will want to start using in the future, such as:
+
+  - [`-Zharden-sls`](https://github.com/rust-lang/rust/issues/116851) (x86_64).
+  - [`-Zindirect-branch-cs-prefix`](https://github.com/rust-lang/rust/pull/140740) (x86).
+  - [`-Zmin-function-alignment`](https://github.com/rust-lang/rust/issues/82232).
+  - [`-Zrandomize-layout`](https://github.com/rust-lang/rust/issues/106764).
+  - [`-Zregparm`](https://github.com/rust-lang/rust/issues/131749) (x86_32).
+  - [`-Zreg-struct-return`](https://github.com/rust-lang/rust/issues/116973) (x86_32).
+  - [`-Zretpoline` and `-Zretpoline-external-thunk`](https://github.com/rust-lang/rust/pull/135927) (x86).
+  - [`-Zsanitizer=kernel-hwaddress` and `-Zsanitizer-recover=kernel-hwaddress`](https://github.com/rust-lang/rust/issues/123615) (arm64).
+  - [`-Zsanitize-kcfi-arity`](https://github.com/rust-lang/rust/issues/138311) (x86_64).
+
+There is also the [`build-std` project goal](https://github.com/rust-lang/rfcs/pull/3873) support that we need as well (or, rather, only "`build-core`" for the Linux kernel), and the [sanitizers project goal](https://rust-lang.github.io/rust-project-goals/2025h2/stabilization-of-sanitizer-support.html).
+
+### What we propose to do about it
+
+We track each compiler feature we're interested in and move them forward towards stabilization. Historically, this was done by either compiler developers or the Rust for Linux team members.
+
+### Work items over the next year
+
+Ideally, the Linux kernel would not need to rely on any of the existing compiler unstable features by the time the period is over, but that is fairly unlikely. Thus, any progress on any feature (or an alternative to using a given unstable feature) would be welcome.
+
+In particular, finishing the work and stabilizing the features that the kernel is already using upstream would be considered a major success.
+
+Longer-term, the Linux kernel does not rely on any compiler-related unstable feature anymore, except for those that may need to be added in the future for different reasons, such as:
+
+  - New hardware features.
+  - New mitigations.
+  - New sanitizers.
+  - New architectures.
+
+For that reason, this goal is conceptually never ending, even if we may reach points where no unstable compiler feature is actually used.
+
+## Team asks
+
+| Team       | Support level | Notes                 |
+|------------|---------------|-----------------------|
+| [compiler] | Medium        | Reviews, RfL meetings |

--- a/src/2026/Rust-for-Linux-language.md
+++ b/src/2026/Rust-for-Linux-language.md
@@ -1,0 +1,79 @@
+# Rust for Linux in stable: language features
+
+| Metadata             |                                    |
+|:---------------------|------------------------------------|
+| Point of contact     | @tomassedovic                      |
+| Status               | Proposed                           |
+| Tracking issue       | [rust-lang/rust-project-goals#116] |
+| Zulip channel        | [#rust-for-linux][channel-rfl]     |
+| [lang] champion      | @joshtriplett                      |
+| [lang-docs] champion | @traviscross                       |
+
+[channel-t-lang]: https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang
+[channel-rfl]: https://rust-lang.zulipchat.com/#narrow/channel/425075-rust-for-linux
+
+## Summary
+
+Continue working towards Rust for Linux on stable. In particular, this goal is focused on the language features.
+
+## Motivation
+
+Getting the Linux kernel to build with stable Rust and, more generally, supporting the needs of the Linux kernel to make Rust a success there, has been a priority for the Rust project and a previous flagship goal: [2024H2](https://rust-lang.github.io/rust-project-goals/2024h2/rfl_stable.html), [2025H1](https://rust-lang.github.io/rust-project-goals/2025h1/rfl.html).
+
+One of the key areas are language features, given the impact they could have on the kernel if they were to change, especially those that may require changes on potentially many source files and/or that may not be easy to workaround with conditional compilation.
+
+The ultimate goal is for the Linux kernel to build on stable Rust, not requiring any unstable features. This is very likely going to take more than one year.
+
+In the meantime, any progress on any feature (or an alternative to using a given unstable feature) is welcome. In particular, finishing the work around `arbitrary_self_types` and `derive_coerce_pointee` and stabilizing them would be considered a major success.
+
+An important design axiom that still applies from previous iterations is "**Don't let perfect be the enemy of good**". The primary goal is to offer stable support for the particular use cases that the Linux kernel requires. Wherever possible we aim to stabilize features completely, but if necessary, we can try to stabilize a subset of functionality that meets the kernel developers' needs while leaving other aspects unstable.
+
+### The status quo
+
+The Linux kernel relies or plans to rely on the following features:
+
+  - [`Deref` / `Receiver`](https://github.com/rust-lang/rust/pull/146095)
+  - [`arbitrary_self_types`](https://github.com/rust-lang/rust/issues/44874)
+  - [`derive_coerce_pointee`](https://github.com/rust-lang/rust/issues/123430)
+  - [`asm_const_ptr`](https://github.com/rust-lang/rust/issues/128464)
+  - [`cfg(no_fp_fmt_parse)`](https://github.com/rust-lang/rust/pull/86048)
+  - [`used_with_arg`](https://github.com/rust-lang/rust/issues/93798)
+  - `compiler_builtins` TODO(tomassedovic) which compiler builtins?
+
+We also depend on the following goals (some of which spun out of the broad Rust for Linux effort):
+
+  - [In-place initialization](https://github.com/rust-lang/rust-project-goals/issues/395)
+  - [Field projections](https://github.com/rust-lang/rust-project-goals/issues/390)
+  - [Supertrait Auto-impl](https://github.com/rust-lang/rfcs/pull/3851)
+
+As well as a set of compiler flags and other features which have their own [project goal](https://github.com/rust-lang/rust-project-goals/issues/407).
+
+### Work items over the next year
+
+| Task                                          | Owner(s)          | Notes |
+|-----------------------------------------------|-------------------|-------|
+| `Deref`/`Receiver` Implementation & docs      | @dingxiangfei2009 |       |
+| `Deref`/`Receiver` Reference PR               | @dingxiangfei2009 |       |
+| `Deref`/`Receiver` Stabilization PR           | @dingxiangfei2009 |       |
+| `arbitrary_self_types` Implementation & docs  | @dingxiangfei2009 |       |
+| `arbitrary_self_types` Reference PR           | @dingxiangfei2009 |       |
+| `arbitrary_self_types` Stabilization PR       | @dingxiangfei2009 |       |
+| `derive(CoercePointee)` Implementation & docs | @dingxiangfei2009 |       |
+| `derive(CoercePointee)` Reference PR          | @dingxiangfei2009 |       |
+| `derive(CoercePointee)` Stabilization PR      | @dingxiangfei2009 |       |
+| `asm_const_ptr` Implementation & docs         | @Darksonn         |       |
+| `asm_const_ptr` Reference PR                  |                   |       |
+| `asm_const_ptr` Style and rustfmt             |                   |       |
+| `asm_const_ptr` Stabilization PR              |                   |       |
+| `cfg(no_fp_fmt_parse)` Reference PR ??        |                   |       |
+| `cfg(no_fp_fmt_parse)` Stabilization PR       |                   |       |
+| `used_with_arg` Implementation & docs         |                   |       |
+| `used_with_arg` Stabilization PR              |                   |       |
+
+## Team asks
+
+| Team        | Support level | Notes                      |
+|-------------|---------------|----------------------------|
+| [lang]      | Medium        | Reviews, Lang/RfL meetings |
+| [lang-docs] | Medium        | Reviews, Lang/RfL meetings |
+| [libs]      | Small         | Reviews                    |


### PR DESCRIPTION
This adds the Lang and Compiler features goals to 2026.

There are other goals (in-place init, field projections and supertrait auto-impl) that will be tracked as separate goals.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/Rust-for-Linux-compiler.md)