### PR TITLE
[2026] Move trait

### DIFF
--- a/src/2026/move-trait.md
+++ b/src/2026/move-trait.md
@@ -26,7 +26,7 @@ immovable. This is a problem, because `Pin` will show up pretty quickly for a
 lot of beginners, making asynchronous networked programming in Rust harder than
 it needs to be.
 
-There a lot of low-level systems like the Linux kernel, or code interacting with
+There are a lot of low-level systems like the Linux kernel, or code interacting with
 C++ that wants to encode immovable types and which would benefit
 from better primitives. For example, in [The Safe Pinned Initialization Problem](https://rust-for-linux.com/the-safe-pinned-initialization-problem) the Rust for Linux problem describes the problem of `Pin` not being able to safely encode self-referential types which must be valid for the entirety of the program’s lifetime.
 


### PR DESCRIPTION
This introduces a 2026 goal for the `Move` auto-trait (tracking: https://github.com/rust-lang/rust/issues/149607). Thanks!

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/move-trait.md)