### PR TITLE
2026 project goal for BorrowSanitizer.

### DIFF
--- a/src/2026/borrowsanitizer.md
+++ b/src/2026/borrowsanitizer.md
@@ -8,6 +8,7 @@
 | Zulip channel    | N/A                                                                              |
 | [compiler] champion    | @RalfJung                                                                               |
 | [opsem] champion    | @RalfJung                                                                              |
+| [lang] champion    | @tmandry                                                                              |
 
 ## Summary
 


### PR DESCRIPTION
Our plans for BorrowSanitizer in 2026, which expand on #392.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/borrowsanitizer.md)