### PR TITLE
Continue MIR Move Elimination in 2026

### DIFF
--- a/src/2026/mir-move-elimination.md
+++ b/src/2026/mir-move-elimination.md
@@ -89,7 +89,7 @@ The end goal of this proposal is to be able to soundly perform move elimination 
 
 | Team         | Support level | Notes          |
 |--------------|---------------|----------------|
-| [lang]       | Medium        | RFC decision   |
-| [compiler]   | Medium        | RFC decision   |
-| [opsem]      | Medium        | Design meeting |
+| [lang]       | Small        | RFC decision   |
+| [compiler]   | Small        | RFC decision   |
+| [opsem]      | Large        | Design meeting |
 | [wg-mir-opt] | Medium        | Design meeting |


### PR DESCRIPTION


[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/mir-move-elimination.md)