### PR TITLE
Add proposal for `#[manually_drop]` experiment and RFC

### DIFF
--- a/src/2026/manually-drop-attr.md
+++ b/src/2026/manually-drop-attr.md
@@ -1,7 +1,7 @@
 # Experiment and RFC for `#[manually_drop]`
 
 | Metadata         |                         | 
-|:---------------- |:----------------------- |
+| :--------------- | ----------------------- |
 | Point of contact | @tmandry                |
 | Status           | Proposed for mentorship |
 | Tracking issue   |                         |
@@ -86,7 +86,7 @@ impl Drop for UringState {
 ### Work items over the next year
 
 | Task                        | Owner(s) | Notes                     |
-|:--------------------------- |:-------- |:------------------------- |
+| --------------------------- | -------- | ------------------------- |
 | Implement a lang experiment |          | @tmandry to find an owner |
 | Write an RFC                |          | @tmandry to find an owner |
 


### PR DESCRIPTION
Add a `#[manually_drop]` attribute to

* Allow C++ bindings to expose struct fields without compatibility hazards, and  
* Make all code that disables default destructor behavior more convenient to use in Rust.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/manually-drop-attr.md)