### PR TITLE
refactor: improve presentation of goals by size

### DIFF
--- a/crates/rust-project-goals/src/gh/issues.rs
+++ b/crates/rust-project-goals/src/gh/issues.rs
@@ -134,9 +134,12 @@ pub fn list_issues_in_milestone(
     repository: &Repository,
     timeframe: &str,
 ) -> Result<Vec<ExistingGithubIssue>> {
+    // Github gets upset if a milestone name is just a number
+    let milestone_name = format!("{timeframe}-goals");
+
     list_issues_cached(
         repository,
-        &[("-m", timeframe)],
+        &[("-m", &milestone_name)],
         Some(format!(".issues-{}.json", timeframe)),
     )
 }

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -36,6 +36,21 @@ lazy_static! {
         Regex::new(r"\(\(\(GOALS NOT ACCEPTED\)\)\)").unwrap();
 }
 
+// List of large goals (goals with at least one Large team ask)
+lazy_static! {
+    pub static ref LARGE_GOAL_LIST: Regex = Regex::new(r"\(\(\(LARGE GOALS\)\)\)").unwrap();
+}
+
+// List of medium goals (goals with at least one Medium ask, no Large asks)
+lazy_static! {
+    pub static ref MEDIUM_GOAL_LIST: Regex = Regex::new(r"\(\(\(MEDIUM GOALS\)\)\)").unwrap();
+}
+
+// List of small goals (goals with only Small or Vibes asks)
+lazy_static! {
+    pub static ref SMALL_GOAL_LIST: Regex = Regex::new(r"\(\(\(SMALL GOALS\)\)\)").unwrap();
+}
+
 lazy_static! {
     pub static ref GOAL_COUNT: Regex = Regex::new(r"\(\(\(#GOALS\)\)\)").unwrap();
 }

--- a/src/2026/README.md
+++ b/src/2026/README.md
@@ -49,16 +49,35 @@ The flagship goals proposed for this roadmap are as follows:
 
 (TBD--typically one paragraph per goal)
 
-### Project goals
-
-The full slate of project goals are as follows. These goals all have identified points of contact who will drive the work forward as well as a viable work plan. The goals specify the level of support needed from the listed Rust teams, which is cataloged in the [reference-level explanation](#reference-level-explanation) section below.
-
-**Invited goals.** Some goals of the goals below are "invited goals", meaning that for that goal to happen we need someone to step up and serve as a point of contact. To find the invited goals, look for the ![Help wanted][] badge in the table below. Invited goals have reserved capacity for teams and a mentor, so if you are someone looking to help Rust progress, they are a great way to get involved.
-
-(((GOALS)))
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
+
+## Goals by work required
+
+### Large goals
+
+Large goals require the engagement of entire team(s). The teams that need to engage with the goal are highlighted in bold.
+
+(((LARGE GOALS)))
+
+### Medium goals
+
+Medium goals require support from an individual, the team champion.
+
+(((MEDIUM GOALS)))
+
+### Smaller/vibes goals
+
+Smaller or vibes goals are covered by standard team processes and do not require dedicated support from anyone.
+
+(((SMALL GOALS)))
+
+## Goals by champion
+
+(((CHAMPIONS)))
+
+## Goals by team
 
 The following table highlights the support level requested from each affected team. Each goal specifies the level of involvement needed:
 

--- a/src/2026/async-future-memory-optimisation.md
+++ b/src/2026/async-future-memory-optimisation.md
@@ -17,7 +17,6 @@
 | Status           | Proposed                                                                         |
 | Tracking issue   |                                                                                  |
 | Zulip channel    | N/A                                                                              |
-| [compiler] champion    | TBD                                                                             |
 
 ## Summary
 

--- a/src/2026/build-std.md
+++ b/src/2026/build-std.md
@@ -1,12 +1,11 @@
 # build-std
 
-| Metadata           |                                    |
-| :--                | :--                                |
-| Point of contact   | @davidtwco                         |
-| Status             | Proposed                           |
-| Zulip channel      | [#project-goals/build-std][zulip]  |
-| Tracking issue     | [rust-lang/rust-project-goals#274] |
-| [cargo] champion | @epage | 
+| Metadata         |                                    |
+|:-----------------|:-----------------------------------|
+| Point of contact | @davidtwco                         |
+| Status           | Proposed                           |
+| Zulip channel    | [#project-goals/build-std][zulip]  |
+| Tracking issue   | [rust-lang/rust-project-goals#274] |
 
 [zulip]: https://rust-lang.zulipchat.com/#narrow/channel/516120-project-goals.2Fbuild-std
 

--- a/src/2026/field-projections.md
+++ b/src/2026/field-projections.md
@@ -8,7 +8,6 @@
 | Tracking issue   | [rust-lang/rust-project-goals#390]                                               |
 | Zulip channel    | [t-lang/custom-refs](https://rust-lang.zulipchat.com/#narrow/channel/522311-t-lang.2Fcustom-refs) |
 | [lang] champion  | @tmandry                                                                         |
-| [compiler] champion  | NEEDED                                                                       |
 | [types] champion  | @lqd                                                                        |
 
 ## Summary

--- a/src/2026/in-place-init.md
+++ b/src/2026/in-place-init.md
@@ -6,7 +6,6 @@
 | Status           | Proposed                             |
 | Tracking issue   | [rust-lang/rust-project-goals#395]   |
 | Zulip channel    | [#t-lang/in-place-init][channel]     |
-| [lang] champion    | TBD |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/528918-t-lang.2Fin-place-init
 

--- a/src/2026/stabilize-cargo-sbom.md
+++ b/src/2026/stabilize-cargo-sbom.md
@@ -7,7 +7,6 @@
 | Tracking issue   |                                                                                  |
 | Other tracking issues | https://github.com/rust-lang/cargo/issues/16565                             |
 | Zulip channel    | N/A                                                                              |
-| [cargo] champion | TBD |
 
 ## Summary
 


### PR DESCRIPTION
I am working through the best way to present and think about the goals. This is the morning's iteration.

e.g.,

<img width="1882" height="1640" alt="image" src="https://github.com/user-attachments/assets/b45a1367-b1fe-4042-807c-90e7cf0544e5" />


[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/README.md)