### PR TITLE
Revert "Add CI job to check mdbook build"

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -9,10 +9,6 @@ on:
   push:
     branches: ["main"]
 
-  # Runs on every pull request targeting the default branch
-  pull_request:
-    branches: [ "main" ]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -59,10 +55,6 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./book/html
-        # Don't upload if this is a pull request against the default
-        # branch (as opposed to a merge or scheduled job). We're just
-        # checking the mdbook build for errors in that case.
-        if: ${{ github.ref == 'refs/heads/main' }}
 
   # Deployment job
   deploy:
@@ -71,8 +63,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    # Don't deploy if this is a pull request against the default branch
-    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This reverts commit 6af764b555991384f1bad5ac8f6398b5711134df.

We've added this to check the proposed goals in CI. But we already have a check for that: `cargo rpg check` / `just check`.

It's just that its regex missed the `2026` goals because they didn't have the `h` suffix.

With that fixed in: commit 11b102c61a2d959c9eaa49183a8681d8d9771490, the original check catches issues with the new goals too (and does it much more quickly) so the pull_request portion of `mdbook build` can be reverted.

We still need to keep the periodic version, as that builds our website.