### PR TITLE
fix mardown table parsing rejecting valid tables

### DIFF
--- a/crates/rust-project-goals/src/markwaydown.rs
+++ b/crates/rust-project-goals/src/markwaydown.rs
@@ -43,7 +43,7 @@ pub fn parse_text(text: Spanned<&str>) -> Result<Vec<Section>> {
     for line in text.lines() {
         let line = line.to_str().unwrap();
         let categorized = categorize_line(line.clone());
-        // eprintln!("line = {:?}", line);
+        // eprintln!("line = {:?}", line.content);
         // eprintln!("categorized = {:?}", categorized);
         match categorized {
             CategorizeLine::Title(level, title) => {
@@ -157,10 +157,13 @@ enum CategorizeLine {
 }
 
 fn categorize_line(line: Spanned<&str>) -> CategorizeLine {
+    // Trimming _may_ slightly mess up spans sometimes, but it's preferable to e.g. failing to parse
+    // tables due to unexpected spaces.
     if line.starts_with("#") {
         let level = line.chars().take_while(|ch| **ch == '#').count();
         CategorizeLine::Title(level, line.trim_start_matches('#').trim().to_string())
     } else if let Some(line) = line
+        .trim()
         .strip_prefix("|")
         .and_then(|line| line.strip_suffix("|"))
     {


### PR DESCRIPTION
Fixes the annoying bug in table parsing due to spaces, which is still causing issues in https://github.com/rust-lang/rust-project-goals/pull/494 for example.

I think this fix shouldn't cause other bugs downstream like rendering, as it seems to be related to validation, but I don't know this codebase that well, you never know.