### PR TITLE
feat: introduce "just add async" theme

### DIFF
--- a/src/2026/afidt-box.md
+++ b/src/2026/afidt-box.md
@@ -1,0 +1,117 @@
+# Box notation for dyn async trait
+
+| Metadata          |                      |
+| :---------------- | -------------------- |
+| Point of contact  | @nikomatsakis        |
+| Status            | Proposed             |
+| Flagship          | Just Add Async       |
+| Tracking issue    |                      |
+| Zulip channel     | [#wg-async][channel] |
+| [lang] champion   | @nikomatsakis        |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
+
+## Summary
+
+Introduce `.box` notation and use it to enable dyn dispatch for traits with async methods. The initial scope is `foo.method().box` where `method()` returns a dyn-compatible RPITIT. In the future `.box` could be used more generally but before expanding it we would like to see progress on the work towards [in-place initialization](./in-place-init.md).
+
+## Motivation
+
+### The status quo
+
+Async fn in traits (AFIT) has been stable since Rust 1.75, but traits with async methods are not dyn-compatible. If you write:
+
+```rust
+trait HttpClient {
+    async fn fetch(&self, url: &str) -> Response;
+}
+```
+
+You cannot use `&dyn HttpClient`. The compiler rejects it because async methods return opaque future types whose size isn't known at compile time, and dyn dispatch requires the caller to allocate space for the return value without knowing the concrete type.
+
+Today, developers work around this by:
+- **Using static dispatch only**: Generics everywhere, increasing compile times and binary size
+- **Manual desugaring**: Write `-> Pin<Box<dyn Future<Output = Response> + Send + '_>>` and lose the ergonomics of `async fn`
+- **Proc macros**: Use crates like [async-trait] or [dynosaur] that transform your code
+
+[async-trait]: https://crates.io/crates/async-trait
+[dynosaur]: https://crates.io/crates/dynosaur
+
+#### The broader problem is complex
+
+Making `dyn Trait` work with unsized return types is a deep problem that has been [explored extensively][dyn-async-series]. The caller must provide storage for the returned value, but doesn't know its size. There are many options one might wish to use, with stack allocation and boxing being the most obvious. The [in-place initialization goal](./in-place-init.md) is exploring the design space here for a fully general solution that allows the caller to have total control. But that design work requires time, and the goal for 2026 is only to settle on a *specific design*, not necessarily to implement it or even stabilize it! In the meantime, Rust's support for async-fn-in-trait is only usable in narrow circumstances.
+
+[dyn-async-series]: https://smallcultfollowing.com/babysteps/series/dyn-async-traits/
+
+#### Boxing is the simplest approach and it's what many users will want
+
+The widespread use of the [async-trait] crate demonstrates that boxing is perfectly acceptable for many applications. `async-trait` transforms `async fn` into a fn that returns `Pin<Box<dyn Future + Send>>`, allocating on every call. Despite this cost, the crate has been downloaded millions of times because for most server and application code, the allocation overhead is negligible compared to the I/O being performed.
+
+The problem with `async-trait` isn't that it boxes. It's that it modifies the *trait definition*, forcing all implementors to box on every call. This means library authors can't use it for public traits where some users need static dispatch (no allocation) while others want dyn dispatch.
+
+What we want is for the *call site* to decide whether to box. A library like Tower could define its `Service` trait using native `async fn`, implementors would write normal async code without any boxing, and generic code using `T: Service` would have zero allocation overhead. But users who need `dyn Service` could opt into boxing at the call site. Once the in-place initialization work proceeds, that same trait would support other allocation strategies too. But boxing unblocks the ecosystem now.
+
+### What we propose to do about it
+
+**The `.box` operator.** We propose to build out an end-to-end solution based on the `.box` operator. The biggest impact on users is that they could invoke async fn via `dyn` trait, but they have to use `.box` at the call site, like so:
+
+```rust
+async fn fetch_data(client: &dyn HttpClient) -> Response {
+    client.fetch(url).box.await
+    //                ---
+    //
+    // Signals that the resulting future will be boxed.
+}
+```
+
+For the purposes of this goal, `.box` would only be usable when calling a trait method where the trait definition returns `-> impl SomeTrait`. We expect it would be generalized in the future to serve as a replacement for `Box::new` but the details of that will depend on the outcome from the [in-place initialization](./in-place-init.md) exploration currently taking place.
+
+**Method-scope dyn compatibility.** An implication of the `.box` design is that we need to make the definition of dyn-compatibility more fine-grained. Today, a trait is only "dyn compatible" if *all* of its methods are dyn-safe -- that is, can be used *in the same way* whether through `dyn` or not. But `async fn` (and `-> impl Trait` methods in general) are not dyn-safe in this way: they can only be used if the user specifies a memory allocation strategy (with `.box` being the first example).
+
+For more details and a broader look, see the [box, box, box][box-post] blog post.
+
+[box-post]: https://smallcultfollowing.com/babysteps/blog/2025/03/24/box-box-box/
+
+### Work items over the next year
+
+| Task                               | Owner(s)         | Notes                                    |
+| ---------------------------------- | ---------------- | ---------------------------------------- |
+| RFC for method-scope dyn compat    | @nikomatsakis    |                                          |
+| RFC for `.box` notation            | @nikomatsakis    | Scoped to RPITIT/async returns initially |
+| Implementation                     | ![Help Wanted][] | Nightly experiment                       |
+| Documentation                      | ![Help Wanted][] |                                          |
+
+## Team asks
+
+| Team       | Support level | Notes                 |
+| ---------- | ------------- | --------------------- |
+| [lang]     | Medium        | RFC decision          |
+| [compiler] | Medium        | Implementation review |
+
+## Frequently asked questions
+
+### Why `.box` instead of implicit boxing?
+
+Explicit is better here. Boxing has runtime cost (allocation), and Rust's philosophy is to make costs visible. `.box` lets you see exactly where allocations happen, which matters for performance-sensitive async code.
+
+### What about the other allocation strategies?
+
+The status quo section describes several options: boxing, in-place initialization, inline storage, and custom allocators. This goal focuses on boxing because it's the option we're most confident about. It's proven by `async-trait`, works everywhere with an allocator, and is simplest to implement.
+
+Other strategies can be added later with different syntax. For example, inline storage might use `.inline::<N>` or similar. The key insight is that we don't need to solve everything at once.
+
+### Could `.box` generalize beyond async?
+
+Yes. The notation could potentially work anywhere you would use `Box::new`, but we don't want to figure out the full desugaring yet. This goal scopes `.box` to method call position (`foo.bar().box`) for RPITIT methods. That includes `async fn`, explicit `-> impl Future`, but also `-> impl Iterator` and similar patterns.
+
+### Why not just use the dynosaur crate?
+
+The dynosaur crate is a good workaround, but native language support would:
+- Avoid proc macro complexity and compile-time overhead
+- Provide better error messages
+- Enable optimizations the compiler can't do through macro-generated code
+- Make the pattern discoverable and standard
+
+### How does this relate to the "Just Add Async" flagship?
+
+Dynamic dispatch is a core Rust pattern. In sync code, you can freely use `&dyn Trait` for most traits. The "Just Add Async" theme is about making async code work like sync code. With `.box`, you can use `&dyn Trait` with async methods. You just need to explicitly box the future, which is a reasonable cost for the flexibility of dynamic dispatch.

--- a/src/2026/ergonomic-rc.md
+++ b/src/2026/ergonomic-rc.md
@@ -4,7 +4,7 @@
 | :---------------- | ---------------------------------- |
 | Point of contact  | @nikomatsakis                      |
 | Status            | Proposed                           |
-| Flagship          | Higher-level Rust                  |
+| Flagship          | [Just Add Async](./flagship-just-add-async.md) |
 | Tracking issue    | [rust-lang/rust-project-goals#107] |
 | Zulip channel     | N/A                                |
 | [lang] champion   | @nikomatsakis                      |

--- a/src/2026/flagship-higher-level-rust.md
+++ b/src/2026/flagship-higher-level-rust.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Making Rust more approachable for quick tasks, prototyping, and application development without sacrificing its core values.
+Making Rust more approachable for quick tasks, prototyping, and teaching without sacrificing its core values.
 
 ## Motivation
 
@@ -12,8 +12,6 @@ Rust is capable of high-level application development, but current tooling creat
 
 * **Starting a program requires project setup.** Even a simple utility needs a project directory, `Cargo.toml`, and `main.rs`. Compare this to Python or JavaScript, where you write one file and run it. Many developers who would benefit from Rust's type system instead reach for scripting languages because the setup cost is too high.
 
-* **Ref-counted types require verbose cloning.** `Rc` and `Arc` require explicit `.clone()` calls and awkward temporary variables when sharing data across closures or async blocks. This ceremony slows iteration and clutters code. Frameworks like Dioxus and tokio-based services rely heavily on shared ownership, and the ergonomic cost has led projects to create custom preprocessors or arena-based designs as workarounds.
-
 The result is a perception gap: Rust seems like "the language for when performance matters" rather than "a language for getting things done."
 
 ### What we are shooting for
@@ -21,8 +19,6 @@ The result is a perception gap: Rust seems like "the language for when performan
 By the end of 2026:
 
 * **Single-file programs run directly.** Write a Rust file with embedded dependencies, make it executable, and run it. No project setup, no separate manifest. Useful for bug reports, teaching, utilities, and prototyping.
-
-* **Ref-counting ergonomics are prototyping on nightly.** A `Share` trait and move expressions will be available on nightly, providing better syntax for cloning into closures. The code remains explicit about where sharing happens, but the boilerplate disappears. Stabilization may follow pending evaluation.
 
 ### Key use cases
 
@@ -32,15 +28,9 @@ By the end of 2026:
 
 * **Personal utilities**: Write small tools in Rust instead of shell scripts. A single-file script with type checking and access to crates.io.
 
-* **Application prototyping**: Focus on the interesting parts when exploring GUI or async designs, rather than fighting clone ergonomics.
-
-* **Production async code**: The "Cloudflare pattern" of cloning multiple values before spawning becomes a single readable expression.
-
 ### Design axioms
 
 * **Lower the floor without lowering the ceiling.** Make simple things simple without compromising Rust's power for complex cases.
-
-* **Explicit is ergonomic.** Visibility into what code does remains important. Remove unnecessary ceremony, not behavior. When you share an `Arc`, the code should say so—just without the boilerplate.
 
 * **Meet developers where they are.** Not every task requires a project structure. Rust should adapt to what the developer is building.
 
@@ -50,18 +40,10 @@ By the end of 2026:
 
 ## Frequently asked questions
 
-### How do these goals relate to each other?
-
-* **Cargo script** addresses the friction of *starting* a Rust program—removing project setup ceremony.
-
-* **Ergonomic ref-counting** addresses friction in *writing* certain programs—particularly async code and GUI applications.
-
-Together they make Rust more approachable: easier to start, more pleasant to write.
-
 ### Does this mean Rust is becoming a scripting language?
 
 No. Rust remains compiled with static types and ownership semantics. Cargo scripting adds convenience for single-file programs while keeping everything that makes Rust valuable. The difference is purely in developer experience.
 
 ### Will these changes affect existing code?
 
-No. Cargo scripting is an addition to how Cargo can be invoked. Ergonomic ref-counting features are opt-in.
+No. Cargo scripting is an addition to how Cargo can be invoked.

--- a/src/2026/flagship-just-add-async.md
+++ b/src/2026/flagship-just-add-async.md
@@ -1,0 +1,92 @@
+# Just Add Async
+
+## Summary
+
+Writing async Rust should be a natural extension of sync Rust: take your sync code, sprinkle some `async` and `await` keywords around in logical places, follow the compiler's guidance, and wind up with working code.
+
+## Motivation
+
+### The status quo
+
+#### Async Rust is widely used
+
+The promise of tight tail latency, low memory usage, and high-level reliable code has made Rust, and async Rust in particular, a popular choice for network services. Rust is now widely used at all levels, from superscalars like Amazon and Microsoft, to simple CRUD apps built on FAAS platforms like Lambda or Azure Functions, to low-level networking on embedded devices.
+
+#### But Async Rust doesn't support standard Rust patterns
+
+Despite this success, async Rust is widely seen as qualitatively harder than sync Rust. Not just more complex, but a different kind of challenge:
+
+> "I feel like there's a ramp in learning and then there's a jump and then there's async over here. And so the goal is to get enough excitement about Rust to where you can jump the chasm of sadness and land on the async Rust side." (from the Rust Vision Doc interviews)
+
+The problem isn't async concepts themselves. Developers understand concurrency (well, mostly). The problem is that **patterns which work in sync Rust don't transfer to async**:
+
+* **Traits:** `async fn` in traits is stable, but you can't use `&dyn Trait` with async methods, and there's no way to require that an impl returns a `Send` future.
+* **Closures:** Async closures are stable, but compiler bugs frequently report invalid `Send` errors, and the trait limitations above make them hard to use in practice.
+* **Recursion:** In sync Rust, recursion just works. In async Rust, it requires arcane signatures with explicit lifetimes, `Box`, `dyn Future`, and `Pin`.
+* **Scoped patterns:** Sync Rust has `std::thread::scope` for borrowing into spawned threads. Async spawn APIs require `'static`, forcing `Arc` everywhere.
+* **Drop:** Destructors are sync-only. Resources that need async cleanup (database connections, network sessions) can't clean up properly in `Drop`.
+
+Each issue has workarounds. But the workarounds require knowledge that doesn't transfer from sync Rust, and the compiler doesn't guide you to them. The result: developers who would otherwise build a network service in Rust hit these walls and wonder if it's worth the trouble.
+
+**The ecosystem is waiting too.** Libraries like Tower remain on 0.x because they can't express the APIs they need. Tower's `Service` trait predates `async fn` in traits and uses complex workarounds. The maintainers want to ship a cleaner design, but they're blocked on language features. Particularly the ability to define one trait that works with both `Send` and non-`Send` futures. So Tower waits, and the middleware ecosystem built on it stays in flux.
+
+### What we are shooting for
+
+The goal is **"just add async"**: patterns that work in sync Rust should work in async Rust without requiring workarounds, restructuring, or arcane incantations. When async does require something extra (like explicit boxing for dyn dispatch), the compiler guides you with clear, actionable errors. Not walls of opaque type errors.
+
+There should be straightforward equivalents for all the "rudiments of Rust":
+
+* [x] Inherent async function definitions and calls to those functions
+* [x] Async closures
+* [x] Static trait dispatch for traits with async functions
+* [ ] Generic functions that make use of those traits ([proposed for 2026](./rtn.md))
+* [ ] Dynamic trait dispatch ([proposed for 2026](./afidt.md))
+* [ ] Iterators (requires a stream trait design and other details)
+* [ ] Convenient ways to write recursive functions
+* [ ] Scoped parallelism (requires [immobile types and guaranteed destructors](./move-trait.md), proposed for 2026)
+* [ ] Async drop and resource cleanup (requires [immobile types and guaranteed destructors](./move-trait.md), proposed for 2026)
+
+### Key use cases
+
+* **Network service development:** Backend services, API servers, data pipelines. The most common async use case. In this scenario, allocation is acceptable. Performance bounds vary by application but consistency is often more important than absolute level of performance.
+
+* **Middleware and composable abstractions:** Libraries like Tower can define `Service` traits that work across runtimes (work-stealing and thread-per-core) without complex workarounds.
+
+### Design axioms
+
+* **Sync patterns should transfer.** If a pattern works in sync Rust, it should work in async Rust. When async requires something extra, the compiler should guide you there.
+
+* **Server-first, but not server-only.** We focus on server and application use cases to ship complete workflows now. But designs should leave space for users with stricter requirements. Features that allocate today can be extended with custom allocators or in-place initialization later. We're not closing doors, we're opening the first one.
+
+* **Unblock the ecosystem, enable experimentation.** The goal isn't just language features. It's enabling libraries like Tower to ship stable APIs, and creating space for exploration of harder problems (in-place initialization, structured concurrency) without blocking on them. Ship end-to-end workflows that work today while leaving room for the designs to evolve.
+
+## 2026 goals
+
+(((FLAGSHIP GOALS: Just Add Async)))
+
+## Frequently asked questions
+
+### What am I agreeing to by accepting this theme?
+
+Accepting this flagship theme means agreeing that:
+
+1. **These problems matter.** The gaps between sync and async Rust are real and worth fixing.
+2. **This direction is right.** Closing these gaps so "just add async" works is the right goal.
+3. **Server-first is the right prioritization.** We ship end-to-end workflows for server/application environments first, with designs that leave space for stricter requirements later.
+
+It does *not* mean agreeing to specific syntax (like `.box`) or implementation details. Those will be decided in individual goal RFCs.
+
+### What about async iterators / streams?
+
+Async iteration is part of this theme's vision, but not a 2026 focus. The 2026 goals target the foundational work: getting async fn in traits and closures fully working. That's enough scope for one year. Exploring streams fully will require those foundations plus [guaranteed destructors](./move-trait.md) (because streams interact with structured concurrency and cancellation). Once the 2026 work lands, streams become much more tractable.
+
+### How do the goals in this theme relate to each other?
+
+The four 2026 goals are largely independent:
+
+- **RTN** enables generic async code and is already RFC'd, waiting on trait solver work
+- **AFIDT / `.box` notation** enables dyn dispatch for async traits
+- **Ergonomic ref-counting** addresses closure capture pain that's amplified by async's `'static` spawn requirements
+- **Immobile types and guaranteed destructors** enables scoped spawn and async drop by letting types opt out of being moved or forgotten
+
+RTN and AFIDT share a dependency on the next-generation trait solver, which is being worked on separately.

--- a/src/2026/flagships.md
+++ b/src/2026/flagships.md
@@ -2,6 +2,11 @@
 
 Flagship themes are long-running efforts that span multiple goal periods. Each theme represents a vision for where Rust is headed, with concrete milestones for this year.
 
+* [Just Add Async](./flagship-just-add-async.md): Patterns that work in sync Rust should work in async Rust. Key 2026 milestones include:
+    * stabilize [return type notation](./rtn.md),
+    * stabilize [async fn in dyn trait](./afidt.md),
+    * prototype [immobile types and guaranteed destructors](./move-trait.md),
+    * prototype [ergonomic ref-counting](./ergonomic-rc.md).
 * [Beyond the `&`](./flagship-beyond-the-ampersand.md): Smart pointers that feel as natural as `&` and `&mut`. Key 2026 milestones include:
     * experimental support for [field projections](./field-projections.md),
     * progress on [reborrow traits](./reborrow-traits.md),
@@ -12,9 +17,8 @@ Flagship themes are long-running efforts that span multiple goal periods. Each t
 * [Constify all the things](./flagship-constify-all-the-things.md): Structs and associated constants in generics, compile-time type introspection. Key 2026 milestones include:
     * stabilize [const generics](./const-generics.md) extensions,
     * prototype [reflection](./reflection-and-comptime.md).
-* [Higher-level Rust](./flagship-higher-level-rust.md): Single-file scripts with dependencies, ergonomic ref-counting. Key 2026 milestones include:
-    * stabilize [cargo-script](./cargo-script.md),
-    * prototype the [Share trait](./ergonomic-rc.md).
+* [Higher-level Rust](./flagship-higher-level-rust.md): Single-file scripts with dependencies. Key 2026 milestones include:
+    * stabilize [cargo-script](./cargo-script.md).
 * [Secure your supply chain](./flagship-secure-your-supply-chain.md): Control over public API dependencies, breaking change detection, SBOM generation. Key 2026 milestones include:
     * stabilize [public/private dependencies](./pub-priv.md),
     * stabilize [SBOM support](./stabilize-cargo-sbom.md).

--- a/src/2026/move-trait.md
+++ b/src/2026/move-trait.md
@@ -1,133 +1,63 @@
-# `Move` auto-trait project goal
+# Immobile types and guaranteed destructors
 
 | Metadata              |                                                                                                  |
 | :-------------------- | ------------------------------------------------------------------------------------------------ |
 | Point of contact      | @jackh726                                                                                        |
 | Status                | Proposed                                                                                         |
+| Flagship              | [Just Add Async](./flagship-just-add-async.md)                                                   |
 | Tracking issue        |                                                                                                  |
 | Other tracking issues | https://github.com/rust-lang/rust/issues/149607                                                  |
 | Zulip channel         | [#t-lang/move-trait](https://rust-lang.zulipchat.com/#narrow/channel/549962-t-lang.2Fmove-trait) |
 
 ## Summary
 
-We’re proposing to introduce a new trait `Move` which enables types to be marked
-as “immovable” via `!Move`. We will implement an MVP in the compiler, write an RFC, and validate the viability of using this in the Linux Kernel.
+We propose to introduce new traits that describe what operations are possible on a type. Today Rust assumes all types can be moved (relocated in memory) and forgotten (via `mem::forget`). We will introduce traits like `Move` and `Forget` that make these capabilities explicit, allowing types to opt out. This follows the precedent set by the [Sized hierarchy work](./scalable-vectors.md), which relaxes the assumption that all types have a compile-time-known size. We will implement MVPs in the compiler, write RFCs, and validate viability through real-world testing in the Linux Kernel.
 
 ## Motivation
 
 ### The status quo
 
-`Pin` is one of the most complicated parts of Rust, and one which even Rust
-experts struggle with. And that makes sense, since `Pin` works very differently from most of other Rust's constructs, and has a lot of subtleties and rules that need to be remembered. Even though the concept of "a type that cannot be moved" is not that difficult to grasp.
+Rust has historically assumed that all values can be moved (relocated in memory) and forgotten (via `mem::forget`, without running destructors). These assumptions are baked into the language: assignment moves values, and `mem::forget` is safe. But some types need to opt out of these capabilities:
 
-Immovability is a really useful property for a low-level programming language to be able to encode. A lot
-of futures generated through Rust’s `async` effect desugaring want to be
-immovable. This is a problem, because `Pin` will show up pretty quickly for a
-lot of beginners, making asynchronous networked programming in Rust harder than
-it needs to be.
+**Immobile types:** A lot of async futures want to be self-referential, but self-referential types can't be safely moved. The current solution is `Pin`, which encodes immovability as a property of *places* rather than *types*. This leads to significant complexity. As [The Safe Pinned Initialization Problem](https://rust-for-linux.com/the-safe-pinned-initialization-problem) describes, `Pin` struggles to safely encode self-referential types in systems like the Linux kernel.
 
-There are a lot of low-level systems like the Linux kernel, or code interacting with
-C++ that wants to encode immovable types and which would benefit
-from better primitives. For example, in [The Safe Pinned Initialization Problem](https://rust-for-linux.com/the-safe-pinned-initialization-problem) the Rust for Linux problem describes the problem of `Pin` not being able to safely encode self-referential types which must be valid for the entirety of the program’s lifetime.
+**Guaranteed destructors:** Some types need their destructors to run. A `Transaction` type might require `commit()` or `rollback()` before cleanup. A scoped task handle must join before the scope exits. But `mem::forget` is safe, so Rust can't guarantee destructors run. This blocks patterns like safe scoped spawn for async, where the spawned task borrows from the parent scope.
 
 ### What we propose to do about it
 
-The difficulties in using `Pin` are mostly because of `Pin`’s design, and not
-the general problem of encoding immovability. `Pin` encodes immovability as a property of _places_, and not of
-_types_. But it still involves types in that encoding, because types still need to opt-in to being
-immovable by implementing `!Unpin`.
+We propose to generalize Rust's type system with new auto-traits that describe what operations are possible on a type. The framing is positive: traits represent capabilities. At the base layer, types may have no special capabilities. We then layer on the things we need:
 
-This project goal is proposing an alternative mechanism for immovability by introducing a
-new auto-trait `Move`. Types implementing `!Move` cannot be moved, and must keep
-a stable address in memory for their entire existence. The `Move` trait looks like this:
+- **`Move`**: The type can be relocated in memory.
+- **`Destruct`**: The type can be implicitly dropped (destructor runs when it goes out of scope).
+- **`Forget`**: The type can be forgotten via `mem::forget` without running its destructor.
+
+This follows the precedent set by the [Sized hierarchy](./scalable-vectors.md) work. Just as that work relaxes "all types have compile-time-known size" to support scalable vectors, this work relaxes "all types can be moved" and "all types can be forgotten."
+
+**The `Move` trait** encodes movability as a property of types rather than places:
 
 ```rust
 #[lang = "move"]
 unsafe auto trait Move {}
 ```
 
-To construct an immovable type at a stable address (e.g. without moving it), we
-will be relying on the work done by
-[#t-lang/in-place-init](https://rust-lang.zulipchat.com/#narrow/channel/528918-t-lang.2Fin-place-init).
-There is no consensus yet on what the final design(s) will look like, but one
-proposed design is the [“placing functions”
-proposal](https://blog.yoshuawuyts.com/placing-functions/) which proposes to
-rewrite the return type with out-pointers. Because `#[placing] fn` functions construct types without moving them, it becomes possible to "return" `!Move` functions from constructors:
+Types implementing `!Move` cannot be moved and must keep a stable address for their entire existence. This is simpler than `Pin` because immovability is a type property, not a place property. Construction of `!Move` types will rely on work from [#t-lang/in-place-init](https://rust-lang.zulipchat.com/#narrow/channel/528918-t-lang.2Fin-place-init).
+
+**The `Forget` trait** lets types opt out of being forgettable:
 
 ```rust
-/// A type which must keep a stable memory address.
-struct MyType { .. }
-unsafe impl !Move for MyType {}
-
-impl MyType {
-    /// Construct an instance of `MyType` at a stable
-    /// address in memory.
-    #[placing]
-    fn new(arg1: ..) -> Self {
-        Self { arg1, .. }
-    }
-}
+// Types implementing !Forget must have their destructors run
+unsafe impl !Forget for ScopedTaskHandle {}
 ```
 
-Sometimes people will want to be able to write types which can be freely moved
-around until they are ready to be placed at their forever-address. In today’s
-system we use a type-state pattern in the form of `MyType` + `Pin<&mut MyType>` where `MyType: !Unpin`:
-
-```rust
-/// A type which may be freely moved around until
-// it is held by a `Pin<&mut T>` reference, after
-// which it may no longer be moved.
-struct MyType { .. }
-impl !Unpin for Move {}
-
-impl IntoMyType {
-    // Construct a new instance of `MyType`.
-    fn new(..) -> Self { .. }
-}
-
-fn main() {
-    let x = MyType::new(..); // 1. Create a new instance of `MyType`.
-    let y = x;               // 1. Move the instance to a new address.
-    let x = pin!(y);         // 2. Mark the instance as immovable.
-    // x: Pin<&mut MyType>
-}
-```
-
-Using `Move` we can do something very similar by introducing a type which can be
-converted into an immovable type. This ends up working very similarly, except that here the final value of `x` is simply of type `MyType` rather than `Pin<&mut MyType>`.
-
-```rust
-/// A type which has a stable memory address.
-struct MyType { .. }
-unsafe impl !Move for MyType {}
-
-/// A type which can be freely moved around.
-struct IntoMyType { .. }
-impl IntoMyType {
-    // Construct a new instance of `IntoMyType`.
-    fn new(..) -> Self { .. }
-    
-    // Convert into an instance of `MyType` at a 
-    // stable memory address.
-    #[placing] into_my_type(self) -> MyType { .. }
-}
-
-fn main() {
-    let x = IntoMyType::new(..); // 1. Create a new instance.
-    let y = x;                   // 2. Move it to a new address.
-    let x = y.into_my_type();    // 3. Make it immovable.
-    // x: MyType
-}
-```
-
-There is a lot more to be said about `Move`, but we plan to expand on that in an RFC.
+With `!Forget`, we could build safe scoped spawn: the handle's destructor joins the task, and because the handle can't be forgotten, the join is guaranteed. This unblocks patterns that are currently impossible in safe Rust.
 
 ### Work items over the next year
 
 | Task                                             | Owner(s)         | Notes                                                                                                                              |
 | ------------------------------------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Compiler implementation                          | @lcnr and @nia-e |                                                                                                                                    |
-| Write the RFC                                    | @yoshuawuyts     |                                                                                                                                    |
+| Compiler implementation for `Move`               | @lcnr and @nia-e |                                                                                                                                    |
+| Write the `Move` RFC                             | @yoshuawuyts     |                                                                                                                                    |
+| Design exploration for guaranteed destructors    | @nikomatsakis    | Explore trait hierarchy options and interaction with existing features                                                             |
 | Test in Linux kernel                             | @bennolossin     | RfL is an important Rust user which uses a lot of self-referential data structures.                                                |
 | Test interactions between `Iterator` and `!Move` | @yoshuawuyts     | It's important to prove that generator-based effects can be desugared to `impl Trait + !Move` so they can support self-references. |
 
@@ -143,20 +73,24 @@ on `Pin`, and would need a migration story to be able to use `Move`. However dep
 
 | Team    | Support level | Notes                                        |
 | ------- | ------------- | -------------------------------------------- |
-| [lang]  | Medium        | Design session needed to work through design |
-| [types] | Medium        | Involved in implementation + review          |
+| [lang]  | Large         | Design session needed to work through design |
+| [types] | Large        | Involved in implementation + review          |
 
 ## Frequently asked questions
 
-### How does this relate to the “pin ergonomics” initiative?
+### How does this relate to the Sized hierarchy work?
+
+The [Sized hierarchy](./scalable-vectors.md) work establishes the pattern: Rust can relax assumptions that were previously universal by introducing trait hierarchies that let types opt out. That work relaxes "all types have compile-time-known size" to support scalable vectors and extern types. This goal applies the same pattern to "all types can be moved" and "all types can be forgotten."
+
+### How does this relate to the "pin ergonomics" initiative?
 
 This work is an alternative to [Project Goal 2025H2: Continue Experimentation with Pin Ergonomics](https://github.com/rust-lang/rust-project-goals/blob/main/src/2025h2/pin-ergonomics.md), which includes the following extensions:
- 
+
  - A new item family `pin` in lvalues, e.g. `&pin x`, `&pin mut x`, `&pin const x`.
- - A one-off overload of Rust’s `Drop` trait, e.g. `fn drop(&pin mut self)`.
+ - A one-off overload of Rust's `Drop` trait, e.g. `fn drop(&pin mut self)`.
  - A new item kind `pin` in patterns, e.g. `&pin <pat>`.
 
-Notably this work does not solve [pin’s duplicate definition
+Notably this work does not solve [pin's duplicate definition
 problem](https://blog.yoshuawuyts.com/why-pin/), meaning that even with these extentions we still end up with `Trait` and `PinnedTrait` variants of existing
 traits. The `Drop` trait being the exception to this, since the initiative is proposing to special-case it using a one-off overload.
 
@@ -165,6 +99,20 @@ problem is with `Pin` and we should improve the way immovable types are encoded
 in Rust instead. With the eventual goal to deprecate `Pin` in Rust entirely.
 
 Because Rust promises to stay backwards-compatible forever, making `pin` a
-language-item on par with `&` and `mut` is something we’ll forever need to keep
+language-item on par with `&` and `mut` is something we'll forever need to keep
 supporting. Given our eventual goal is to deprecate `Pin`, we do not believe
 that we should make `pin` a part of the language. Which is why `Move` is not just a complimentary proposal, but intended as an alternative.
+
+### What enables safe scoped spawn?
+
+Safe scoped spawn requires guaranteed destructors. The pattern: spawn returns a handle whose destructor joins the task. If you could `mem::forget` the handle, the task could outlive the scope and access dangling references. With `!Forget`, the handle's destructor is guaranteed to run, making the pattern safe. This is one of the key motivations for the guaranteed destructors portion of this goal.
+
+### Where can I read more about this design space?
+
+Several blog posts explore this area:
+
+- [Move, Destruct, Leak](https://smallcultfollowing.com/babysteps/blog/2025/10/21/move-destruct-leak/) explores the trait hierarchy for destructors and forgetting. Note that unlike this post, we don't believe `Move` should be a supertrait of `Destruct`. It's useful to have types that can be destructed/dropped but not moved (e.g., self-referential types that need cleanup).
+- [Must move types](https://smallcultfollowing.com/babysteps/blog/2023/03/16/must-move-types/) introduces the concept of types that force callers to take specific actions.
+- [Ergonomic Self-Referential Types for Rust](https://blog.yoshuawuyts.com/self-referential-types/) and [its follow-up](https://blog.yoshuawuyts.com/self-referential-types-2/) explore the `Move` trait design.
+- [Why Pin is a part of trait signatures](https://blog.yoshuawuyts.com/why-pin/) explains the problems with `Pin` that motivate this work.
+- [Placing functions](https://blog.yoshuawuyts.com/placing-functions/) proposes syntax for constructing `!Move` types in place.

--- a/src/2026/rtn.md
+++ b/src/2026/rtn.md
@@ -1,0 +1,131 @@
+# Stabilize Return Type Notation
+
+| Metadata          |                      |
+| :---------------- | -------------------- |
+| Point of contact  | @nikomatsakis        |
+| Status            | Proposed             |
+| Flagship          | Just Add Async       |
+| Tracking issue    |                      |
+| Zulip channel     | [#wg-async][channel] |
+| [lang] champion   | @nikomatsakis        |
+| [types] champion  |                      |
+
+[channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
+
+## Summary
+
+Stabilize return type notation (RTN) for trait methods, enabling bounds like `T::method(..): Send` to constrain the return types of async trait methods. Extend RTN to async closures via a new RFC. This unblocks widespread use of async fn in traits and async closures by solving the ["Send bound" problem][sb].
+
+[sb]: https://smallcultfollowing.com/babysteps/blog/2023/02/01/async-trait-send-bounds-part-1-intro/
+
+## Motivation
+
+### The status quo
+
+Async fn in traits (AFIT) has been stable since Rust 1.75, but when users attempt to use it in a public trait, they get a warning:
+
+```rust
+pub trait Foo {
+    async fn bar();
+}
+
+// warning: use of `async fn` in public traits is discouraged as auto trait bounds cannot be specified
+//  --> src/lib.rs:2:5
+//   |
+// 2 |     async fn bar();
+//   |     ^^^^^
+//   |
+//   = note: you can suppress this lint if you plan to use the trait only in your own code, or do not care about auto traits like `Send` on the `Future`
+//   = note: `#[warn(async_fn_in_trait)]` on by default
+// help: you can alternatively desugar to a normal `fn` that returns `impl Future` and add any desired bounds such as `Send`, but these cannot be relaxed without a breaking API change
+//   |
+// 2 -     async fn bar();
+// 2 +     fn bar() -> impl std::future::Future<Output = ()> + Send;
+//   |
+```
+
+This warning is highlighting a problem known as the ["Send bound" problem][sb], which means that generic functions referencing a trait with an async functions (or any `impl Trait`-returning function) cannot specify that this async function must return a `Send` future. This blocks ecosystem crates like [Tower](https://crates.io/crates/tower) from using AFIT in their public APIs.
+
+Return type notation (RTN), proposed in [RFC #3654], solves this by letting you write:
+
+```rust
+fn spawn_service<S>(service: S)
+where
+    S: Service,
+    S::call(..): Send,  // RTN: the future returned by `call` must be Send
+{
+    tokio::spawn(async move {
+        service.call(request).await
+    });
+}
+```
+
+RTN has been fully implemented and is available on nightly under the feature flag `return_type_notation`.
+
+[RFC #3654]: https://rust-lang.github.io/rfcs/3654-return-type-notation.html
+
+#### RTN for async closures
+
+RTN solves the Send bound problem for trait methods, but what about async closures? Consider this function:
+
+```rust
+async fn foo<F>(x: F)
+where
+    F: AsyncFn(&str) -> Option<()>,
+{
+    tokio::spawn(x("hello"));
+}
+```
+
+This doesn't compile because `tokio::spawn` requires a `Send` future, but we have no way to express that `x()` returns one. The `F::method(..)` syntax doesn't work because there is no method name to reference.
+
+The [async closure RFC][ext] mentioned a syntax like `F(..): Send`, but this wasn't widely discussed during that RFC process. We'd like to explore the syntactic design space, author an RFC, and implement this on nightly. As a stretch goal, we could stabilize it.
+
+[ext]: https://rust-lang.github.io/rfcs/3668-async-closures.html#interaction-with-return-type-notation-naming-the-future-returned-by-calling
+
+#### RTN stabilization is blocked on the new solver
+
+A [stabilization PR][stab-pr] was opened but had to be closed because RTN's ability to name opaque types in arbitrary positions interacts with unresolved questions in the trait solver around TAIT (type alias impl trait) and ATPIT (associated type position impl trait).
+
+[stab-pr]: https://github.com/rust-lang/rust/pull/138424
+
+### What we propose to do about it
+
+We propose to author an RFC extending RTN to async closures, explore the design space, and implement it on nightly.
+
+In addition, as there is now a plan to [stabilize the next-generation trait solver](./next-solver.md), we would like to stabilize return-type-notation for trait methods.
+
+### Work items over the next year
+
+RTN stabilization for trait methods depends on progress in the [next-generation trait solver](./next-solver.md) goal, specifically around opaque type handling. However, RTN support for async closures can proceed in parallel.
+
+| Task                             | Owner(s)         | Notes                                         |
+|----------------------------------|------------------|-----------------------------------------------|
+| RFC for RTN on async closures    | @nikomatsakis    | `F(..): Send` syntax, explore design space    |
+| Implement RTN for async closures | ![Help Wanted][] | After RFC acceptance                          |
+| Update stabilization report      | ![Help Wanted][] | Address concerns from closed PR               |
+
+## Team asks
+
+| Team    | Support level | Notes                               |
+|---------|---------------|-------------------------------------|
+| [lang]  | Large         | Stabilization decision              |
+| [types] | Large         | Stabilization decision, solver work |
+
+## Frequently asked questions
+
+### What was the blocker on the previous stabilization attempt?
+
+The [stabilization PR][stab-pr] was closed because RTN allows naming opaque types in positions that weren't previously possible. As lcnr noted:
+
+> RTN allows naming opaque types in arbitrary positions. This means we get nearly all implementation issues preventing TAIT, at least in theory.
+
+The concern was that stabilizing RTN could lock in behaviors that would conflict with how TAIT/ATPIT need to work in the new trait solver. The resolution path is to complete the relevant trait solver work first.
+
+### How does this relate to the "Just Add Async" flagship?
+
+RTN is the key to making async fn in traits usable in practice. Without it, trait authors must choose between:
+- Using `async fn` but preventing generic code from requiring `Send`
+- Using explicit `-> impl Future<Output=T> + Send` but losing the ergonomics of `async fn`
+
+RTN eliminates this tradeoff, letting patterns from sync Rust transfer naturally to async.


### PR DESCRIPTION
This adds a new flagship theme, *just add async*:

> Writing async Rust should be a natural extension of sync Rust: take your sync code, sprinkle some `async` and `await` keywords around in logical places, follow the compiler's guidance, and wind up with working code.

and uses it for 

* `.box` (new proposed goal)
* ergonomic rc (recategorized)
* move trait (expanded to cover guaranteed destrutors)
* RTN (new proposed goal)



[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/move-trait.md)