### PR TITLE
Update manually drop attr project goal as per discussion

### DIFF
--- a/src/2026/manually-drop-attr.md
+++ b/src/2026/manually-drop-attr.md
@@ -87,7 +87,7 @@ impl Drop for UringState {
 
 #### Proposal 2: Add a `drop_in_place` method to the `Drop` trait
 
-Add a `drop_in_place` method to the `Drop` trait, which is called by the compiler when a type is dropped.
+Add a `drop_in_place` method to the `Destruct` trait, which is called by the compiler instead of the normal drop glue when a type is dropped.
 
 1. If the type has implemented `drop_in_place`, it is called instead of the normal drop glue. No other code is run on drop, in particular this does not recurse into the fields.
 


### PR DESCRIPTION
Updates the `manually-drop-attr` project goal as per the discussion at [#project-goals/2026-workshop > Info regarding Experiment for #&#91;manually_drop&#93; project goal](https://rust-lang.zulipchat.com/#narrow/channel/546987-project-goals.2F2026-workshop/topic/Info.20regarding.20Experiment.20for.20.23.5Bmanually_drop.5D.20project.20goal/with/572016060)

cc: @Nadrieril 

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/manually-drop-attr.md)