### PR TITLE
reflection-and-comptime.md: fix link to demonstration comparison

### DIFF
--- a/src/2026/reflection-and-comptime.md
+++ b/src/2026/reflection-and-comptime.md
@@ -126,7 +126,7 @@ const fn type_of(id: TypeId) -> &'static Type;
 
 These functions can't be run at runtime, because that would require there to be some global table somewhere that maps all `TypeId`s to their repr. This is an obvious no-go in my book.
 
-an demonstration impl (absolutely not salvageable for anything that could be landed!) can be found [here](https://github.com/rust-lang/rust/compare/master...oli-obk:rust:compile-time-reflection)
+A demonstration impl (absolutely not salvageable for anything that could be landed!) can be found [here](https://github.com/rust-lang/rust/compare/main...oli-obk:rust:compile-time-reflection).
 
 ### Why not continue where uwuflection left off?
 


### PR DESCRIPTION
Broken by default branch renaming in November 2025

While there add a missing period and fix the first word.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/reflection-and-comptime.md)