### PR TITLE
Link new tracking issues and mark accepted

### DIFF
--- a/src/2026/a-mir-formality.md
+++ b/src/2026/a-mir-formality.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                  |
 | :--------------- | -------------------------------------------------------------------------------- |
 | Point of contact | @jackh726                                                                        |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#122]                                               |
 | Zulip channel    | [#types/formality]                                                               |
 | [types] champion | @jackh726                                                                        |

--- a/src/2026/aarch64_pointer_authentication_pauthtest.md
+++ b/src/2026/aarch64_pointer_authentication_pauthtest.md
@@ -1,12 +1,14 @@
 # AArch64 Pointer Authentication using aarch64-unknown-linux-pauthtest target on Linux ELF platforms
 
 | Metadata             |                                                 |
-| :------------------- | ------------------------------------------------|
+| :--                  | :--                                             |
 | Point of contact     | @jchlanda                                       |
 | [compiler] champion  | @davidtwco                                      |
 | Status               | Proposed                                        |
 | Other tracking issue | https://github.com/rust-lang/rust/issues/148640 |
 | Zulip channel        | N/A                                             |
+| Tracking issue       | [rust-lang/rust-project-goals#618]              |
+
 
 ## Summary
 

--- a/src/2026/aarch64_pointer_authentication_pauthtest.md
+++ b/src/2026/aarch64_pointer_authentication_pauthtest.md
@@ -4,7 +4,7 @@
 | :--                  | :--                                             |
 | Point of contact     | @jchlanda                                       |
 | [compiler] champion  | @davidtwco                                      |
-| Status               | Proposed                                        |
+| Status               | Accepted                                        |
 | Other tracking issue | https://github.com/rust-lang/rust/issues/148640 |
 | Zulip channel        | N/A                                             |
 | Tracking issue       | [rust-lang/rust-project-goals#618]              |

--- a/src/2026/afidt-box.md
+++ b/src/2026/afidt-box.md
@@ -3,7 +3,7 @@
 | Metadata            |                                                          |
 | :--                 | :--                                                      |
 | Point of contact    | @nikomatsakis                                            |
-| Status              | Proposed                                                 |
+| Status              | Accepted                                                 |
 | What and why        | Enable dyn dispatch for async traits via `.box` notation |
 | Timespan            | 2026-2027                                                |
 | Needs               | Contributor                                              |

--- a/src/2026/afidt-box.md
+++ b/src/2026/afidt-box.md
@@ -1,18 +1,19 @@
 # Box notation for dyn async trait
 
-| Metadata         |                      |
-|:-----------------|----------------------|
-| Point of contact | @nikomatsakis        |
-| Status           | Proposed             |
-| What and why     | Enable dyn dispatch for async traits via `.box` notation |
-| Timespan         | 2026-2027            |
-| Needs            | Contributor          |
-| Roadmap          | Just add async       |
-| Tracking issue   |                      |
-| Highlight        | Async and ergonomic RC |
-| Zulip channel    | [#wg-async][channel] |
-| [lang] champion  | @nikomatsakis        |
-| [compiler] champion | @TaKO8Ki          |
+| Metadata            |                                                          |
+| :--                 | :--                                                      |
+| Point of contact    | @nikomatsakis                                            |
+| Status              | Proposed                                                 |
+| What and why        | Enable dyn dispatch for async traits via `.box` notation |
+| Timespan            | 2026-2027                                                |
+| Needs               | Contributor                                              |
+| Roadmap             | Just add async                                           |
+| Tracking issue      | [rust-lang/rust-project-goals#625]                       |
+| Highlight           | Async and ergonomic RC                                   |
+| Zulip channel       | [#wg-async][channel]                                     |
+| [lang] champion     | @nikomatsakis                                            |
+| [compiler] champion | @TaKO8Ki                                                 |
+
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
 

--- a/src/2026/arbitrary-self-types.md
+++ b/src/2026/arbitrary-self-types.md
@@ -1,19 +1,20 @@
 # Arbitrary Self Types
 
-| Metadata              |                         |
-|:----------------------|-------------------------|
-| Point of contact      | @dingxiangfei2009       |
-| Status                | Proposed                |
+| Metadata              |                                                                                           |
+| :--                   | :--                                                                                       |
+| Point of contact      | @dingxiangfei2009                                                                         |
+| Status                | Proposed                                                                                  |
 | What and why          | Let user-defined smart pointers work as method receivers and support `dyn Trait` coercion |
-| Roadmap               | Rust for Linux          |
-| Roadmap               | Beyond the `&`          |
-| Tracking issue        |                         |
-| Other tracking issues | [rust-lang/rust#44874], [rust-lang/rust#146095], [rust-lang/rust#123430] |
-| Highlight             | Custom pointer types    |
-| Zulip channel         | N/A                     |
-| [lang] champion       | @tmandry                |
-| [types] champion      | @jackh726               |
-| [lang-docs] champion  | @traviscross            |
+| Roadmap               | Rust for Linux                                                                            |
+| Roadmap               | Beyond the `&`                                                                            |
+| Tracking issue        | [rust-lang/rust-project-goals#619]                                                        |
+| Other tracking issues | [rust-lang/rust#44874], [rust-lang/rust#146095], [rust-lang/rust#123430]                  |
+| Highlight             | Custom pointer types                                                                      |
+| Zulip channel         | N/A                                                                                       |
+| [lang] champion       | @tmandry                                                                                  |
+| [types] champion      | @jackh726                                                                                 |
+| [lang-docs] champion  | @traviscross                                                                              |
+
 
 ## Summary
 

--- a/src/2026/arbitrary-self-types.md
+++ b/src/2026/arbitrary-self-types.md
@@ -3,7 +3,7 @@
 | Metadata              |                                                                                           |
 | :--                   | :--                                                                                       |
 | Point of contact      | @dingxiangfei2009                                                                         |
-| Status                | Proposed                                                                                  |
+| Status                | Accepted                                                                                  |
 | What and why          | Let user-defined smart pointers work as method receivers and support `dyn Trait` coercion |
 | Roadmap               | Rust for Linux                                                                            |
 | Roadmap               | Beyond the `&`                                                                            |

--- a/src/2026/assumptions_on_binders.md
+++ b/src/2026/assumptions_on_binders.md
@@ -4,7 +4,7 @@
 | :--              | :--                                 |
 | Point of contact | @BoxyUwU                            |
 | Roadmap          | Project Zero                        |
-| Status           | Proposed                            |
+| Status           | Accepted                            |
 | Tracking issue   | [rust-lang/rust-project-goals#621]  |
 | Zulip channel    | N/A (just make a thread in t-types) |
 | [types] champion | @BoxyUwU                            |

--- a/src/2026/assumptions_on_binders.md
+++ b/src/2026/assumptions_on_binders.md
@@ -1,13 +1,14 @@
 # Assumptions on Binders 
 
-| Metadata         |                                                                                  |
-| :--------------- | -------------------------------------------------------------------------------- |
-| Point of contact | @BoxyUwU |
-| Roadmap          | Project Zero |
-| Status           | Proposed |
-| Tracking issue   |     |
+| Metadata         |                                     |
+| :--              | :--                                 |
+| Point of contact | @BoxyUwU                            |
+| Roadmap          | Project Zero                        |
+| Status           | Proposed                            |
+| Tracking issue   | [rust-lang/rust-project-goals#621]  |
 | Zulip channel    | N/A (just make a thread in t-types) |
-| [types] champion | @BoxyUwU |
+| [types] champion | @BoxyUwU                            |
+
 
 ## Summary
 

--- a/src/2026/async-future-memory-optimisation.md
+++ b/src/2026/async-future-memory-optimisation.md
@@ -1,12 +1,13 @@
 # Async Future Memory Optimisation
 
-| Metadata            |                   |
-| :------------------ | ----------------- |
-| Point of contact    | @dingxiangfei2009 |
-| Status              | Proposed          |
-| Tracking issue      |                   |
-| Zulip channel       | N/A               |
-| [compiler] champion | @tmandry          |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @dingxiangfei2009                  |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#622] |
+| Zulip channel       | N/A                                |
+| [compiler] champion | @tmandry                           |
+
 
 ## Summary
 

--- a/src/2026/async-future-memory-optimisation.md
+++ b/src/2026/async-future-memory-optimisation.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @dingxiangfei2009                  |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#622] |
 | Zulip channel       | N/A                                |
 | [compiler] champion | @tmandry                           |

--- a/src/2026/async-statemachine-optimisation.md
+++ b/src/2026/async-statemachine-optimisation.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @diondokter                        |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Needs               | Funding                            |
 | Tracking issue      | [rust-lang/rust-project-goals#623] |
 | Zulip channel       | N/A                                |

--- a/src/2026/async-statemachine-optimisation.md
+++ b/src/2026/async-statemachine-optimisation.md
@@ -1,14 +1,15 @@
 # Async statemachine optimisation
 
-| Metadata            |             |
-|:--------------------|-------------|
-| Point of contact    | @diondokter |
-| Status              | Proposed    |
-| Needs               | Funding     |
-| Tracking issue      |             |
-| Zulip channel       | N/A         |
-| Needs | Funding |
-| [compiler] champion | @eholk      |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @diondokter                        |
+| Status              | Proposed                           |
+| Needs               | Funding                            |
+| Tracking issue      | [rust-lang/rust-project-goals#623] |
+| Zulip channel       | N/A                                |
+| Needs               | Funding                            |
+| [compiler] champion | @eholk                             |
+
 
 ## Summary
 

--- a/src/2026/borrowsanitizer.md
+++ b/src/2026/borrowsanitizer.md
@@ -1,14 +1,15 @@
 # BorrowSanitizer
 
-| Metadata         |                                                                                  |
-| :--------------- | -------------------------------------------------------------------------------- |
-| Point of contact | @icmccorm                                                                         |
-| Status           | Proposed                                                                         |
-| Tracking issue   |                                                                                  |
-| Zulip channel    | N/A                                                                              |
-| [compiler] champion    | @RalfJung                                                                               |
-| [opsem] champion    | @RalfJung                                                                              |
-| [lang] champion    | @tmandry                                                                              |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @icmccorm                          |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#624] |
+| Zulip channel       | N/A                                |
+| [compiler] champion | @RalfJung                          |
+| [opsem] champion    | @RalfJung                          |
+| [lang] champion     | @tmandry                           |
+
 
 ## Summary
 

--- a/src/2026/borrowsanitizer.md
+++ b/src/2026/borrowsanitizer.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @icmccorm                          |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#624] |
 | Zulip channel       | N/A                                |
 | [compiler] champion | @RalfJung                          |

--- a/src/2026/build-std.md
+++ b/src/2026/build-std.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 |:-----------------|:-----------------------------------|
 | Point of contact | @davidtwco                         |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | What and why     | Let Cargo rebuild the standard library from source for custom targets and configurations |
 | Roadmap          | Rust for Linux                     |
 | Highlight        | Build-std                          |

--- a/src/2026/cargo-cross-workspace-cache.md
+++ b/src/2026/cargo-cross-workspace-cache.md
@@ -1,12 +1,13 @@
 # Cargo cross workspace cache
 
-| Metadata         |                                                                                  |
-| :--------------- | -------------------------------------------------------------------------------- |
-| Point of contact | @ranger-ross                                                                     |
-| Status           | Proposed                                                                         |
-| Tracking issue   |                                                                                  |
-| Zulip channel    | N/A                                                                              |
-| [cargo] champion | @epage                                                                           |
+| Metadata         |                                    |
+| :--              | :--                                |
+| Point of contact | @ranger-ross                       |
+| Status           | Proposed                           |
+| Tracking issue   | [rust-lang/rust-project-goals#626] |
+| Zulip channel    | N/A                                |
+| [cargo] champion | @epage                             |
+
 
 ## Summary
 

--- a/src/2026/cargo-cross-workspace-cache.md
+++ b/src/2026/cargo-cross-workspace-cache.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 | :--              | :--                                |
 | Point of contact | @ranger-ross                       |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#626] |
 | Zulip channel    | N/A                                |
 | [cargo] champion | @epage                             |

--- a/src/2026/cargo-lints.md
+++ b/src/2026/cargo-lints.md
@@ -1,11 +1,12 @@
 # Stabilize Cargo's linting system
 
 | Metadata         |                                                                                  |
-| :--------------- | -------------------------------------------------------------------------------- |
+| :--              | :--                                                                              |
 | Point of contact | @epage                                                                           |
 | Status           | Proposed                                                                         |
-| Tracking issue   |      |
+| Tracking issue   | [rust-lang/rust-project-goals#650]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
+
 
 ## Summary
 

--- a/src/2026/cargo-lints.md
+++ b/src/2026/cargo-lints.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                  |
 | :--              | :--                                                                              |
 | Point of contact | @epage                                                                           |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#650]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
 

--- a/src/2026/cargo-plumbing.md
+++ b/src/2026/cargo-plumbing.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @epage                                                                           |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Needs            | Contributor                                                                      |
 | Tracking issue   | [rust-lang/rust-project-goals#264]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |

--- a/src/2026/cargo-script.md
+++ b/src/2026/cargo-script.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                  |
 | :--------------- | -------------------------------------------------------------------------------- |
 | Point of contact | @epage                                                                           |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Tracking issue   | [rust-lang/rust-project-goals#119]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |
 | Highlight        | Cargo script                                                                     |

--- a/src/2026/cargo-semver-checks.md
+++ b/src/2026/cargo-semver-checks.md
@@ -3,7 +3,7 @@
 | Metadata           |                                    |
 |:-------------------|------------------------------------|
 | Point of contact   | @obi1kenobi                        |
-| Status             | Proposed                           |
+| Status             | Accepted                           |
 | Tracking issue     | [rust-lang/rust-project-goals#104] |
 | Zulip channel      | N/A                                |
 | [cargo] champion   | @epage                             |

--- a/src/2026/const-generics.md
+++ b/src/2026/const-generics.md
@@ -3,7 +3,7 @@
 | Metadata         |                                     |
 | :--------------- | ----------------------------------- |
 | Point of contact | @BoxyUwU                            |
-| Status           | Proposed                            |
+| Status           | Accepted                            |
 | What and why     | Finish "the rest" of Const Generics |
 | Roadmap          | Constify all the things             |
 | Roadmap          | Rust for Linux                      |

--- a/src/2026/const-traits.md
+++ b/src/2026/const-traits.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 | :--------------- | ---------------------------------- |
 | Point of contact | @fee1-dead                         |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | What and why     | Let `const fn` call trait methods so compile-time code can use generics and standard library traits |
 | Tracking issue   | [rust-lang/rust-project-goals#106] |
 | Zulip channel    | #t-compiler/project-const-traits   |

--- a/src/2026/dictionary-passing-style-experiment.md
+++ b/src/2026/dictionary-passing-style-experiment.md
@@ -1,14 +1,15 @@
 # Dictionary Passing Style Experiment
 
-| Metadata         |                                                                                  |
-| :--------------- | -------------------------------------------------------------------------------- |
-| Point of contact | @Nadrieril                                                                       |
-| Status           | Proposed                                                                         |
+| Metadata         |                                                                                                                             |
+| :--              | :--                                                                                                                         |
+| Point of contact | @Nadrieril                                                                                                                  |
+| Status           | Proposed                                                                                                                    |
 | What and why     | Experiment with converting where-clauses to use dictionary passing style, avoiding many implementation bugs by construction |
-| Roadmap          | Project Zero                 |
-| Tracking issue   |                                                                                  |
-| Zulip channel    |                                                                                  |
-| [types] champion | @lcnr                                                                            |
+| Roadmap          | Project Zero                                                                                                                |
+| Tracking issue   | [rust-lang/rust-project-goals#630]                                                                                          |
+| Zulip channel    |                                                                                                                             |
+| [types] champion | @lcnr                                                                                                                       |
+
 
 ## Summary
 

--- a/src/2026/dictionary-passing-style-experiment.md
+++ b/src/2026/dictionary-passing-style-experiment.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                                                             |
 | :--              | :--                                                                                                                         |
 | Point of contact | @Nadrieril                                                                                                                  |
-| Status           | Proposed                                                                                                                    |
+| Status           | Accepted                                                                                                                    |
 | What and why     | Experiment with converting where-clauses to use dictionary passing style, avoiding many implementation bugs by construction |
 | Roadmap          | Project Zero                                                                                                                |
 | Tracking issue   | [rust-lang/rust-project-goals#630]                                                                                          |

--- a/src/2026/ergonomic-rc.md
+++ b/src/2026/ergonomic-rc.md
@@ -3,7 +3,7 @@
 | Metadata         |                                               |
 |:-----------------|-----------------------------------------------|
 | Point of contact | @nikomatsakis                                 |
-| Status           | Proposed                                      |
+| Status           | Accepted                                      |
 | What and why     | A `Share` trait for clone-as-alias types and `move($expr)` for precise closure capture control |
 | Needs            | Contributor                                   |
 | Roadmap          | [Just add async](./roadmap-just-add-async.md) |

--- a/src/2026/expansion-time-evaluation.md
+++ b/src/2026/expansion-time-evaluation.md
@@ -1,15 +1,16 @@
 # Architectural groundwork for expansion-time evaluation
 
-| Metadata         |                            |
-| :--------------- | -------------------------- |
-| Point of contact | @tmandry                   |
-| Status           | Proposed                   |
-| Flagship         | Constify all the things    |
-| [types] champion | @oli-obk |
-| [compiler] champion | @petrochenkov |
-| Tracking issue   |                            |
-| Zulip channel    | N/A                        |
-| Needs            | Funding                    |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @tmandry                           |
+| Status              | Proposed                           |
+| Flagship            | Constify all the things            |
+| [types] champion    | @oli-obk                           |
+| [compiler] champion | @petrochenkov                      |
+| Tracking issue      | [rust-lang/rust-project-goals#620] |
+| Zulip channel       | N/A                                |
+| Needs               | Funding                            |
+
 
 ## Summary
 

--- a/src/2026/expansion-time-evaluation.md
+++ b/src/2026/expansion-time-evaluation.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @tmandry                           |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Flagship            | Constify all the things            |
 | [types] champion    | @oli-obk                           |
 | [compiler] champion | @petrochenkov                      |

--- a/src/2026/experimental-language-specification.md
+++ b/src/2026/experimental-language-specification.md
@@ -1,13 +1,14 @@
 # Case study for experimental language specification, with integration into project teams and processes
 
-| Metadata         |                                                                                  |
-| :---------------- | -------------------------------------------------------------------------------- |
-| Point of contact  | @jackh726 |
-| Status            | Proposed |
-| Tracking issue    | |
-| Zulip channel     | Likely a combination of #t-types and #t-spec |
-| [lang] champion | @joshtriplett |
-| [types] champion | @jackh726 |
+| Metadata         |                                              |
+| :--              | :--                                          |
+| Point of contact | @jackh726                                    |
+| Status           | Proposed                                     |
+| Tracking issue   | [rust-lang/rust-project-goals#627]           |
+| Zulip channel    | Likely a combination of #t-types and #t-spec |
+| [lang] champion  | @joshtriplett                                |
+| [types] champion | @jackh726                                    |
+
 
 ## Summary
 

--- a/src/2026/experimental-language-specification.md
+++ b/src/2026/experimental-language-specification.md
@@ -3,7 +3,7 @@
 | Metadata         |                                              |
 | :--              | :--                                          |
 | Point of contact | @jackh726                                    |
-| Status           | Proposed                                     |
+| Status           | Accepted                                     |
 | Tracking issue   | [rust-lang/rust-project-goals#627]           |
 | Zulip channel    | Likely a combination of #t-types and #t-spec |
 | [lang] champion  | @joshtriplett                                |

--- a/src/2026/field-projections.md
+++ b/src/2026/field-projections.md
@@ -3,7 +3,7 @@
 | Metadata             |                                           |
 | :------------------- | ----------------------------------------- |
 | Point of contact     | @BennoLossin                              |
-| Status               | Proposed                                  |
+| Status               | Accepted                                  |
 | What and why         | Access fields through smart pointers and pinned references, not just `&` and `&mut` |
 | Timespan             | 2026-2028                                 |
 | Roadmap              | Beyond the `&`                            |

--- a/src/2026/high-level-ml.md
+++ b/src/2026/high-level-ml.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @ZuseZ4                            |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#647] |
 | Zulip channel       | N/A                                |
 | [lang] champion     | @traviscross                       |

--- a/src/2026/high-level-ml.md
+++ b/src/2026/high-level-ml.md
@@ -1,13 +1,14 @@
 # Project goal - High-Level ML optimizations
 
-| Metadata            |              |
-|:--------------------|--------------|
-| Point of contact    | @ZuseZ4      |
-| Status              | Proposed     |
-| Tracking issue      |              |
-| Zulip channel       | N/A          |
-| [lang] champion     | @traviscross |
-| [compiler] champion | @oli-obk     |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @ZuseZ4                            |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#647] |
+| Zulip channel       | N/A                                |
+| [lang] champion     | @traviscross                       |
+| [compiler] champion | @oli-obk                           |
+
 
 ## Motivation
 

--- a/src/2026/improve-cg_clif-performance.md
+++ b/src/2026/improve-cg_clif-performance.md
@@ -1,13 +1,14 @@
 # Improve `rustc_codegen_cranelift` performance
 
-| Metadata            |          |
-| :------------------ | -------- |
-| Point of contact    | @bjorn3  |
-| Status              | Proposed |
-| Tracking issue      |          |
-| Zulip channel       | N/A      |
-| Needs               | Funding  |
-| [compiler] champion | @bjorn3  |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @bjorn3                            |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#639] |
+| Zulip channel       | N/A                                |
+| Needs               | Funding                            |
+| [compiler] champion | @bjorn3                            |
+
 
 ## Summary
 

--- a/src/2026/improve-cg_clif-performance.md
+++ b/src/2026/improve-cg_clif-performance.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @bjorn3                            |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#639] |
 | Zulip channel       | N/A                                |
 | Needs               | Funding                            |

--- a/src/2026/improve-std-unsafe.md
+++ b/src/2026/improve-std-unsafe.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 | :--              | :--                                |
 | Point of contact | @hxuhack                           |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#640] |
 | Zulip channel    | N/A                                |
 

--- a/src/2026/improve-std-unsafe.md
+++ b/src/2026/improve-std-unsafe.md
@@ -1,11 +1,12 @@
 # Improving Unsafe Code Documentation in the Rust Standard Library
 
-| Metadata         |                                                                                  |
-| :--------------- | -------------------------------------------------------------------------------- |
-| Point of contact | @hxuhack                                   |
-| Status           | Proposed                                                                         |
-| Tracking issue   |      |
-| Zulip channel    | N/A  |
+| Metadata         |                                    |
+| :--              | :--                                |
+| Point of contact | @hxuhack                           |
+| Status           | Proposed                           |
+| Tracking issue   | [rust-lang/rust-project-goals#640] |
+| Zulip channel    | N/A                                |
+
 
 ## Summary
 

--- a/src/2026/in-place-init.md
+++ b/src/2026/in-place-init.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @Darksonn                          |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | What and why     | Align on a language approach for creating values directly at their final location without moving |
 | Timespan         | 2026-2028                          |
 | Roadmap          | Beyond the `&`                     |

--- a/src/2026/incremental-system-rethought.md
+++ b/src/2026/incremental-system-rethought.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @blyxyas                           |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#641] |
 | [compiler] champion | @jackh726                          |
 | Zulip channel       | N/A                                |

--- a/src/2026/incremental-system-rethought.md
+++ b/src/2026/incremental-system-rethought.md
@@ -1,12 +1,13 @@
 # Incremental Systems Rethought
 
-| Metadata            |           |
-|:--------------------|-----------|
-| Point of contact    | @blyxyas  |
-| Status              | Proposed  |
-| Tracking issue      |           |
-| [compiler] champion | @jackh726 |
-| Zulip channel       | N/A       |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @blyxyas                           |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#641] |
+| [compiler] champion | @jackh726                          |
+| Zulip channel       | N/A                                |
+
 
 ## Summary
 

--- a/src/2026/interactive-cargo-tree.md
+++ b/src/2026/interactive-cargo-tree.md
@@ -1,12 +1,13 @@
 # Interactive cargo-tree: TUI for Cargo's dependency graph visualization
 
-| Metadata             |                    |
-| :------------------- | ------------------ |
-| Point of contact     | @orhun             |
-| Status               | Proposed           |
-| Tracking issue       |                    |
-| Other tacking issues | [#11213], [#15473] |
-| Zulip channel        | [TUI for Cargo]    |
+| Metadata             |                                    |
+| :--                  | :--                                |
+| Point of contact     | @orhun                             |
+| Status               | Proposed                           |
+| Tracking issue       | [rust-lang/rust-project-goals#642] |
+| Other tacking issues | [#11213], [#15473]                 |
+| Zulip channel        | [TUI for Cargo]                    |
+
 
 ## Summary
 

--- a/src/2026/interactive-cargo-tree.md
+++ b/src/2026/interactive-cargo-tree.md
@@ -3,7 +3,7 @@
 | Metadata             |                                    |
 | :--                  | :--                                |
 | Point of contact     | @orhun                             |
-| Status               | Proposed                           |
+| Status               | Accepted                           |
 | Tracking issue       | [rust-lang/rust-project-goals#642] |
 | Other tacking issues | [#11213], [#15473]                 |
 | Zulip channel        | [TUI for Cargo]                    |

--- a/src/2026/interactive-cargo-tree.md
+++ b/src/2026/interactive-cargo-tree.md
@@ -5,7 +5,7 @@
 | Point of contact     | @orhun                             |
 | Status               | Accepted                           |
 | Tracking issue       | [rust-lang/rust-project-goals#642] |
-| Other tacking issues | [#11213], [#15473]                 |
+| Other tracking issues | [#11213], [#15473]                 |
 | Zulip channel        | [TUI for Cargo]                    |
 
 

--- a/src/2026/interop-problem-map.md
+++ b/src/2026/interop-problem-map.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 |:--------------------|:-----------------------------------|
 | Point of contact    | @teor2345                          |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#388] |
 | Zulip channel       | [t-lang/interop][channel]          |
 | [compiler] champion | @oli-obk                           |

--- a/src/2026/libc-1.0.md
+++ b/src/2026/libc-1.0.md
@@ -1,12 +1,13 @@
 # libc 1.0 release readiness
 
 | Metadata              |                                                                      |
-| :-------------------- | -------------------------------------------------------------------- |
+| :--                   | :--                                                                  |
 | Point of contact      | @JohnTitor                                                           |
 | Status                | Proposed                                                             |
-| Tracking issue        |  |
+| Tracking issue        | [rust-lang/rust-project-goals#657]                                   |
 | Other tracking issues | [rust-lang/libc#3248](https://github.com/rust-lang/libc/issues/3248) |
 | Zulip channel         | N/A                                                                  |
+
 
 ## Summary
 

--- a/src/2026/libc-1.0.md
+++ b/src/2026/libc-1.0.md
@@ -3,7 +3,7 @@
 | Metadata              |                                                                      |
 | :--                   | :--                                                                  |
 | Point of contact      | @JohnTitor                                                           |
-| Status                | Proposed                                                             |
+| Status                | Accepted                                                             |
 | Tracking issue        | [rust-lang/rust-project-goals#657]                                   |
 | Other tracking issues | [rust-lang/libc#3248](https://github.com/rust-lang/libc/issues/3248) |
 | Zulip channel         | N/A                                                                  |

--- a/src/2026/library-api-evolution.md
+++ b/src/2026/library-api-evolution.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @Amanieu                           |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#633] |
 | Zulip channel       | N/A                                |
 | [libs-api] champion | @Amanieu                           |

--- a/src/2026/library-api-evolution.md
+++ b/src/2026/library-api-evolution.md
@@ -1,15 +1,16 @@
 # Evolving the standard library API across editions
 
-| Metadata            |          |
-| :------------------ | -------- |
-| Point of contact    | @Amanieu |
-| Status              | Proposed |
-| Tracking issue      |          |
-| Zulip channel       | N/A      |
-| [libs-api] champion | @Amanieu |
-| [edition] champion  | @ehuss   |
-| [compiler] champion | @yaahc   |
-| [rustdoc] champion  | @GuillaumeGomez |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @Amanieu                           |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#633] |
+| Zulip channel       | N/A                                |
+| [libs-api] champion | @Amanieu                           |
+| [edition] champion  | @ehuss                             |
+| [compiler] champion | @yaahc                             |
+| [rustdoc] champion  | @GuillaumeGomez                    |
+
 
 ## Summary
 

--- a/src/2026/libtest-json.md
+++ b/src/2026/libtest-json.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                  |
 | :--------------- | -------------------------------------------------------------------------------- |
 | Point of contact | @epage                                   |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Needs            | Contributor                                                                      |
 | Tracking issue     | [rust-lang/rust-project-goals#255] |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |

--- a/src/2026/macro-improvements.md
+++ b/src/2026/macro-improvements.md
@@ -1,12 +1,13 @@
 # Declarative (`macro_rules!`) macro improvements
 
-| Metadata         |               |
-| :--------------- | ------------- |
-| Point of contact | @joshtriplett |
-| Status           | Proposed      |
-| Tracking issue   |               |
-| Zulip channel    | #t-lang       |
-| [lang] champion  | @joshtriplett |
+| Metadata         |                                    |
+| :--              | :--                                |
+| Point of contact | @joshtriplett                      |
+| Status           | Proposed                           |
+| Tracking issue   | [rust-lang/rust-project-goals#629] |
+| Zulip channel    | #t-lang                            |
+| [lang] champion  | @joshtriplett                      |
+
 
 ## Summary
 

--- a/src/2026/macro-improvements.md
+++ b/src/2026/macro-improvements.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 | :--              | :--                                |
 | Point of contact | @joshtriplett                      |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#629] |
 | Zulip channel    | #t-lang                            |
 | [lang] champion  | @joshtriplett                      |

--- a/src/2026/manually-drop-attr.md
+++ b/src/2026/manually-drop-attr.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @thunderseethe                     |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Needs               | Funding                            |
 | Tracking issue      | [rust-lang/rust-project-goals#628] |
 | Zulip channel       | N/A                                |

--- a/src/2026/manually-drop-attr.md
+++ b/src/2026/manually-drop-attr.md
@@ -1,15 +1,16 @@
 # Control over Drop semantics
 
-| Metadata            |                |
-|:--------------------|----------------|
-| Point of contact    | @thunderseethe |
-| Status              | Proposed   |
-| Needs               | Funding        |
-| Tracking issue      |                |
-| Zulip channel       | N/A            |
-| [lang] champion     | @Nadrieril     |
-| [opsem] champion    | @CAD97         |
-| [compiler] champion | @oli-obk       |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @thunderseethe                     |
+| Status              | Proposed                           |
+| Needs               | Funding                            |
+| Tracking issue      | [rust-lang/rust-project-goals#628] |
+| Zulip channel       | N/A                                |
+| [lang] champion     | @Nadrieril                         |
+| [opsem] champion    | @CAD97                             |
+| [compiler] champion | @oli-obk                           |
+
 
 ## Summary
 

--- a/src/2026/mcdc-coverage-support.md
+++ b/src/2026/mcdc-coverage-support.md
@@ -1,14 +1,15 @@
 # Implement and Maintain MC/DC Coverage Support
 
-| Metadata         |                                                              |
-| :--------------- | ------------------------------------------------------------ |
-| Point of contact | @RenjiSann                                                   |
-| Status           | Proposed                                                     |
-| What and why     | MC/DC and decision coverage in rustc, required by DO-178C, ISO 26262, and IEC 61508 for safety certification |
-| Roadmap          | Safety-Critical Rust                                         |
-| Tracking issue   |                                                              |
-| Zulip channel    | [mc/dc-support][mcdc-zulip] |
-| [compiler] champion | @davidtwco |
+| Metadata            |                                                                                                              |
+| :--                 | :--                                                                                                          |
+| Point of contact    | @RenjiSann                                                                                                   |
+| Status              | Proposed                                                                                                     |
+| What and why        | MC/DC and decision coverage in rustc, required by DO-178C, ISO 26262, and IEC 61508 for safety certification |
+| Roadmap             | Safety-Critical Rust                                                                                         |
+| Tracking issue      | [rust-lang/rust-project-goals#638]                                                                           |
+| Zulip channel       | [mc/dc-support][mcdc-zulip]                                                                                  |
+| [compiler] champion | @davidtwco                                                                                                   |
+
 
 ## Summary
 

--- a/src/2026/mcdc-coverage-support.md
+++ b/src/2026/mcdc-coverage-support.md
@@ -3,7 +3,7 @@
 | Metadata            |                                                                                                              |
 | :--                 | :--                                                                                                          |
 | Point of contact    | @RenjiSann                                                                                                   |
-| Status              | Proposed                                                                                                     |
+| Status              | Accepted                                                                                                     |
 | What and why        | MC/DC and decision coverage in rustc, required by DO-178C, ISO 26262, and IEC 61508 for safety certification |
 | Roadmap             | Safety-Critical Rust                                                                                         |
 | Tracking issue      | [rust-lang/rust-project-goals#638]                                                                           |

--- a/src/2026/mir-move-elimination.md
+++ b/src/2026/mir-move-elimination.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 |:-----------------|:-----------------------------------|
 | Point of contact | @Amanieu                           |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#396] |
 | Zulip channel    | N/A                                |
 | [lang] champion  | @Amanieu                           |

--- a/src/2026/mirroring.md
+++ b/src/2026/mirroring.md
@@ -3,7 +3,7 @@
 | Metadata             |                                    |
 | :--                  | :--                                |
 | Point of contact     | @walterhpearce                     |
-| Status               | Proposed                           |
+| Status               | Accepted                           |
 | Tracking issue       | [rust-lang/rust-project-goals#637] |
 | Zulip channel        | [#tbd-signing]                     |
 | [rustup] champion    | @djc                               |

--- a/src/2026/mirroring.md
+++ b/src/2026/mirroring.md
@@ -1,15 +1,16 @@
 # Implement Verifiable Mirroring Prototype
 
-| Metadata             |                  |
-|:---------------------|------------------|
-| Point of contact     | @walterhpearce   |
-| Status               | Proposed         |
-| Tracking issue       |                  |
-| Zulip channel        | [#tbd-signing]   |
-| [rustup] champion    | @djc             |
-| [cargo] champion     | @arlosi          |
-| [infra] champion     | @Mark-Simulacrum |
-| [crates-io] champion | @LawnGnome       |
+| Metadata             |                                    |
+| :--                  | :--                                |
+| Point of contact     | @walterhpearce                     |
+| Status               | Proposed                           |
+| Tracking issue       | [rust-lang/rust-project-goals#637] |
+| Zulip channel        | [#tbd-signing]                     |
+| [rustup] champion    | @djc                               |
+| [cargo] champion     | @arlosi                            |
+| [infra] champion     | @Mark-Simulacrum                   |
+| [crates-io] champion | @LawnGnome                         |
+
 
 [#tbd-signing]: https://rust-lang.zulipchat.com/#narrow/channel/417663-tbd-signing
 

--- a/src/2026/move-trait.md
+++ b/src/2026/move-trait.md
@@ -1,18 +1,19 @@
 # Immobile types and guaranteed destructors
 
-| Metadata              |                                                                                                  |
-| :-------------------- | ------------------------------------------------------------------------------------------------ |
-| Point of contact      | @jackh726                                                                                        |
-| Status                | Proposed                                                                                         |
+| Metadata              |                                                                                                      |
+| :--                   | :--                                                                                                  |
+| Point of contact      | @jackh726                                                                                            |
+| Status                | Proposed                                                                                             |
 | What and why          | Let types opt out of being moved or forgotten, enabling scoped spawn, async drop, and pin-by-default |
-| Timespan              | 2026-2027                                                                                        |
-| Roadmap               | [Just add async](./roadmap-just-add-async.md)                                                    |
-| Roadmap               | [Rust for Linux](./roadmap-rust-for-linux.md)                                                    |
-| Tracking issue        |                                                                                                  |
-| Other tracking issues | https://github.com/rust-lang/rust/issues/149607                                                  |
-| Zulip channel         | [#t-lang/move-trait](https://rust-lang.zulipchat.com/#narrow/channel/549962-t-lang.2Fmove-trait) |
-| [types] champion      | @lcnr                                                                                            |
-| [lang] champion | @jackh726 |
+| Timespan              | 2026-2027                                                                                            |
+| Roadmap               | [Just add async](./roadmap-just-add-async.md)                                                        |
+| Roadmap               | [Rust for Linux](./roadmap-rust-for-linux.md)                                                        |
+| Tracking issue        | [rust-lang/rust-project-goals#635]                                                                   |
+| Other tracking issues | https://github.com/rust-lang/rust/issues/149607                                                      |
+| Zulip channel         | [#t-lang/move-trait](https://rust-lang.zulipchat.com/#narrow/channel/549962-t-lang.2Fmove-trait)     |
+| [types] champion      | @lcnr                                                                                                |
+| [lang] champion       | @jackh726                                                                                            |
+
 
 ## Summary
 

--- a/src/2026/move-trait.md
+++ b/src/2026/move-trait.md
@@ -3,7 +3,7 @@
 | Metadata              |                                                                                                      |
 | :--                   | :--                                                                                                  |
 | Point of contact      | @jackh726                                                                                            |
-| Status                | Proposed                                                                                             |
+| Status                | Accepted                                                                                             |
 | What and why          | Let types opt out of being moved or forgotten, enabling scoped spawn, async drop, and pin-by-default |
 | Timespan              | 2026-2027                                                                                            |
 | Roadmap               | [Just add async](./roadmap-just-add-async.md)                                                        |

--- a/src/2026/next-solver.md
+++ b/src/2026/next-solver.md
@@ -3,7 +3,7 @@
 | Metadata              |                                           |
 |:----------------------|-------------------------------------------|
 | Point of contact      | @lcnr                                     |
-| Status                | Proposed                                  |
+| Status                | Accepted                                  |
 | What and why          | Replace the existing trait solver with a sound, maintainable implementation that unblocks soundness fixes and async features |
 | Roadmap               | Project Zero                 |
 | Roadmap               | Just add async                            |

--- a/src/2026/open-enums.md
+++ b/src/2026/open-enums.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @kupiakos                          |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#645] |
 | Zulip channel       | N/A                                |
 | [lang] champion     | @scottmcm                          |

--- a/src/2026/open-enums.md
+++ b/src/2026/open-enums.md
@@ -1,14 +1,15 @@
 # Open Enums
 
-| Metadata         |           |
-|:-----------------|-----------|
-| Point of contact | @kupiakos |
-| Status           | Proposed  |
-| Tracking issue   |           |
-| Zulip channel    | N/A       |
-| [lang] champion  | @scottmcm |
-| [compiler] champion  | @madsmtm |
-| [opsem] champion | @chorman0773 |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @kupiakos                          |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#645] |
+| Zulip channel       | N/A                                |
+| [lang] champion     | @scottmcm                          |
+| [compiler] champion | @madsmtm                           |
+| [opsem] champion    | @chorman0773                       |
+
 
 @joshtriplett can serve as the lang champion do it if Scott can't.
 

--- a/src/2026/open-namespaces.md
+++ b/src/2026/open-namespaces.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @epage                                                                           |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Needs            | Contributor                                                                      |
 | Tracking issue   | [rust-lang/rust-project-goals#256]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |

--- a/src/2026/overloading-for-ffi.md
+++ b/src/2026/overloading-for-ffi.md
@@ -1,12 +1,13 @@
 # Nightly support for function overloading in FFI bindings
 
-| Metadata         |          |
-| :--------------- | -------- |
-| Point of contact | @ssbr    |
-| Status           | Proposed |
-| Tracking issue   |          |
-| Zulip channel    | N/A      |
-| [lang] champion  | @tmandry |
+| Metadata         |                                    |
+| :--              | :--                                |
+| Point of contact | @ssbr                              |
+| Status           | Proposed                           |
+| Tracking issue   | [rust-lang/rust-project-goals#643] |
+| Zulip channel    | N/A                                |
+| [lang] champion  | @tmandry                           |
+
 
 ## Summary
 

--- a/src/2026/overloading-for-ffi.md
+++ b/src/2026/overloading-for-ffi.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 | :--              | :--                                |
 | Point of contact | @ssbr                              |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#643] |
 | Zulip channel    | N/A                                |
 | [lang] champion  | @tmandry                           |

--- a/src/2026/parallel-front-end.md
+++ b/src/2026/parallel-front-end.md
@@ -3,7 +3,7 @@
 | Metadata                     |                                          |
 | :--------------------------- | ---------------------------------------- |
 | Point of contact             | @SparrowLii                              |
-| Status                       | Proposed                                 |
+| Status                       | Accepted                                 |
 | Tracking issue               | [rust-lang/rust-project-goals#121]       |
 | See also                     | [rust-lang/rust#113349]                  |
 | Zulip channel                | [#t-compiler/wg-parallel-rustc][channel] |

--- a/src/2026/pin-ergonomics.md
+++ b/src/2026/pin-ergonomics.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 |:--------------------|:-----------------------------------|
 | Point of contact    | @frank-king                        |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#389] |
 | Zulip channel       | N/A                                |
 | [compiler] champion | @oli-obk                           |

--- a/src/2026/polonius.md
+++ b/src/2026/polonius.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 |:-----------------|------------------------------------|
 | Point of contact | @lqd                               |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#118] |
 | Zulip channel    | [#t-types/polonius][channel]       |
 | [types] champion | @jackh726                          |

--- a/src/2026/pub-priv.md
+++ b/src/2026/pub-priv.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                  |
 |:-----------------|----------------------------------------------------------------------------------|
 | Point of contact | @epage                                                                           |
-| Status           | Proposed                                                                         |
+| Status           | Accepted                                                                         |
 | Needs            | Contributor                                                                      |
 | Tracking issue   | [rust-lang/rust-project-goals#272]                                               |
 | Zulip channel    | N/A (an existing stream can be re-used or new streams can be created on request) |

--- a/src/2026/reborrow-traits.md
+++ b/src/2026/reborrow-traits.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 | :--------------- | ---------------------------------- |
 | Point of contact | @aapoalas                          |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | What and why     | Extend automatic reborrowing to user-defined types like `Pin<&mut T>` and custom smart pointers |
 | Timespan         | 2026-2027                          |
 | Roadmap          | Beyond the `&`                     |

--- a/src/2026/redesigning-super-let.md
+++ b/src/2026/redesigning-super-let.md
@@ -1,13 +1,14 @@
 # Redesigning `super let`: Flexible Temporary Lifetime Extension
 
-| Metadata            |              |
-| :------------------ | ------------ |
-| Point of contact    | @dianne      |
-| Status              | Proposed     |
-| Tracking issue      |              |
-| Zulip channel       | N/A          |
-| [lang] champion     | @traviscross |
-| [compiler] champion | @dianne      |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @dianne                            |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#648] |
+| Zulip channel       | N/A                                |
+| [lang] champion     | @traviscross                       |
+| [compiler] champion | @dianne                            |
+
 
 ## Summary
 

--- a/src/2026/redesigning-super-let.md
+++ b/src/2026/redesigning-super-let.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @dianne                            |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#648] |
 | Zulip channel       | N/A                                |
 | [lang] champion     | @traviscross                       |

--- a/src/2026/reflection-and-comptime.md
+++ b/src/2026/reflection-and-comptime.md
@@ -3,7 +3,7 @@
 | Metadata             |                                    |
 |:---------------------|:-----------------------------------|
 | Point of contact     | @oli-obk                           |
-| Status               | Proposed                           |
+| Status               | Accepted                           |
 | What and why         | Compile-time type reflection via `const fn` so `serialize(&my_struct)` works without derives |
 | Timespan             | 2026-2028                          |
 | Roadmap              | Constify all the things            |

--- a/src/2026/rtn.md
+++ b/src/2026/rtn.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                                    |
 | :--              | :--                                                                                                |
 | Point of contact | @traviscross                                                                                       |
-| Status           | Proposed                                                                                           |
+| Status           | Accepted                                                                                           |
 | What and why     | Name opaque types and bound async return types so `async fn` in traits works with `Send` and `dyn` |
 | Needs            | Contributor                                                                                        |
 | Roadmap          | Just add async                                                                                     |

--- a/src/2026/rtn.md
+++ b/src/2026/rtn.md
@@ -1,16 +1,17 @@
 # Prepare TAIT + RTN for stabilization
 
-| Metadata         |                      |
-|:-----------------|----------------------|
-| Point of contact | @traviscross         |
-| Status           | Proposed             |
+| Metadata         |                                                                                                    |
+| :--              | :--                                                                                                |
+| Point of contact | @traviscross                                                                                       |
+| Status           | Proposed                                                                                           |
 | What and why     | Name opaque types and bound async return types so `async fn` in traits works with `Send` and `dyn` |
-| Needs            | Contributor          |
-| Roadmap          | Just add async       |
-| Tracking issue   |                      |
-| Zulip channel    | [#wg-async][channel] |
-| [lang] champion  | @traviscross         |
-| [types] champion | @lcnr                |
+| Needs            | Contributor                                                                                        |
+| Roadmap          | Just add async                                                                                     |
+| Tracking issue   | [rust-lang/rust-project-goals#646]                                                                 |
+| Zulip channel    | [#wg-async][channel]                                                                               |
+| [lang] champion  | @traviscross                                                                                       |
+| [types] champion | @lcnr                                                                                              |
+
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/
 

--- a/src/2026/rust-for-linux-compiler-features.md
+++ b/src/2026/rust-for-linux-compiler-features.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 |:--------------------|------------------------------------|
 | Point of contact    | @tomassedovic                      |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | What and why        | Stabilize compiler features the Linux kernel depends on so it can build with only stable Rust |
 | Timespan            | 2026-2027                          |
 | Roadmap             | Rust for Linux                     |

--- a/src/2026/safe-unsafe-for-safety-critical.md
+++ b/src/2026/safe-unsafe-for-safety-critical.md
@@ -1,14 +1,15 @@
 # Normative Documentation for Sound `unsafe` Rust
 
-| Metadata         |                                                              |
-| :--------------- | ------------------------------------------------------------ |
-| Point of contact | @PLeVasseur                                                  |
-| Status           | Proposed                                                     |
+| Metadata         |                                                                                                                |
+| :--              | :--                                                                                                            |
+| Point of contact | @PLeVasseur                                                                                                    |
+| Status           | Proposed                                                                                                       |
 | What and why     | Normative documentation for common `unsafe` patterns so safety-critical developers have authoritative guidance |
-| Roadmap          | Safety-Critical Rust                                         |
-| Tracking issue   |                                                              |
-| Zulip channel    | N/A                                                          |
-| [opsem] champion    | @RalfJung                                                          |
+| Roadmap          | Safety-Critical Rust                                                                                           |
+| Tracking issue   | [rust-lang/rust-project-goals#644]                                                                             |
+| Zulip channel    | N/A                                                                                                            |
+| [opsem] champion | @RalfJung                                                                                                      |
+
 
 ## Summary
 

--- a/src/2026/safe-unsafe-for-safety-critical.md
+++ b/src/2026/safe-unsafe-for-safety-critical.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                                                |
 | :--              | :--                                                                                                            |
 | Point of contact | @PLeVasseur                                                                                                    |
-| Status           | Proposed                                                                                                       |
+| Status           | Accepted                                                                                                       |
 | What and why     | Normative documentation for common `unsafe` patterns so safety-critical developers have authoritative guidance |
 | Roadmap          | Safety-Critical Rust                                                                                           |
 | Tracking issue   | [rust-lang/rust-project-goals#644]                                                                             |

--- a/src/2026/safety-critical-lints-in-clippy.md
+++ b/src/2026/safety-critical-lints-in-clippy.md
@@ -1,13 +1,14 @@
 # Establish a Spot for Safety-Critical Lints in Clippy
 
-| Metadata         |                                                              |
-| :--------------- | ------------------------------------------------------------ |
-| Point of contact | @PLeVasseur                                                  |
-| Status           | Proposed                                                     |
+| Metadata         |                                                                                            |
+| :--              | :--                                                                                        |
+| Point of contact | @PLeVasseur                                                                                |
+| Status           | Proposed                                                                                   |
 | What and why     | A sustainable home in Clippy for safety-critical coding standard lints from the Consortium |
-| Roadmap          | Safety-Critical Rust                                         |
-| Tracking issue   |                                                              |
-| Zulip channel    | N/A                                                          |
+| Roadmap          | Safety-Critical Rust                                                                       |
+| Tracking issue   | [rust-lang/rust-project-goals#631]                                                         |
+| Zulip channel    | N/A                                                                                        |
+
 
 ## Summary
 

--- a/src/2026/safety-critical-lints-in-clippy.md
+++ b/src/2026/safety-critical-lints-in-clippy.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                            |
 | :--              | :--                                                                                        |
 | Point of contact | @PLeVasseur                                                                                |
-| Status           | Proposed                                                                                   |
+| Status           | Accepted                                                                                   |
 | What and why     | A sustainable home in Clippy for safety-critical coding standard lints from the Consortium |
 | Roadmap          | Safety-Critical Rust                                                                       |
 | Tracking issue   | [rust-lang/rust-project-goals#631]                                                         |

--- a/src/2026/scalable-vectors.md
+++ b/src/2026/scalable-vectors.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @davidtwco                         |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#270] |
 | Highlight           | Try, never, extern types           |
 | [compiler] champion | @davidtwco                         |

--- a/src/2026/specialization.md
+++ b/src/2026/specialization.md
@@ -1,16 +1,17 @@
 # Stabilize concrete type specialization
 
-| Metadata              |                      |
-|:----------------------|----------------------|
-| Point of contact      | @tmandry             |
-| Status                | Proposed             |
-| Needs                 | Funding              |
-| Tracking issue        |                      |
-| Zulip channel         | N/A                  |
-| Help wanted           | N/A                  |
-| Other tracking issues | rust-lang/rust#31844 |
-| [lang] champion       | @tmandry             |
-| [types] champion      | @jackh726            |
+| Metadata              |                                    |
+| :--                   | :--                                |
+| Point of contact      | @tmandry                           |
+| Status                | Proposed                           |
+| Needs                 | Funding                            |
+| Tracking issue        | [rust-lang/rust-project-goals#652] |
+| Zulip channel         | N/A                                |
+| Help wanted           | N/A                                |
+| Other tracking issues | rust-lang/rust#31844               |
+| [lang] champion       | @tmandry                           |
+| [types] champion      | @jackh726                          |
+
 
 ## Summary
 

--- a/src/2026/specialization.md
+++ b/src/2026/specialization.md
@@ -3,7 +3,7 @@
 | Metadata              |                                    |
 | :--                   | :--                                |
 | Point of contact      | @tmandry                           |
-| Status                | Proposed                           |
+| Status                | Accepted                           |
 | Needs                 | Funding                            |
 | Tracking issue        | [rust-lang/rust-project-goals#652] |
 | Zulip channel         | N/A                                |

--- a/src/2026/stabilization-of-sanitizer-support.md
+++ b/src/2026/stabilization-of-sanitizer-support.md
@@ -3,7 +3,7 @@
 | Metadata                               |                                    |
 |:---------------------------------------|:-----------------------------------|
 | Point of contact                       | @jakos-sec                         |
-| Status                                 | Proposed                           |
+| Status                                 | Accepted                           |
 | Tracking issue                         | [rust-lang/rust-project-goals#403] |
 | Zulip channel                          | N/A                                |
 | [project-exploit-mitigations] champion | @rcvalle                           |

--- a/src/2026/stabilize-cargo-sbom.md
+++ b/src/2026/stabilize-cargo-sbom.md
@@ -3,7 +3,7 @@
 | Metadata              |                                                 |
 | :--                   | :--                                             |
 | Point of contact      | @Shnatsel                                       |
-| Status                | Proposed                                        |
+| Status                | Accepted                                        |
 | Needs                 | Contributor                                     |
 | Tracking issue        | [rust-lang/rust-project-goals#649]              |
 | Other tracking issues | https://github.com/rust-lang/cargo/issues/16565 |

--- a/src/2026/stabilize-cargo-sbom.md
+++ b/src/2026/stabilize-cargo-sbom.md
@@ -1,14 +1,15 @@
 # Stabilize Cargo SBOM precursor
 
 | Metadata              |                                                 |
-|:----------------------|-------------------------------------------------|
+| :--                   | :--                                             |
 | Point of contact      | @Shnatsel                                       |
 | Status                | Proposed                                        |
 | Needs                 | Contributor                                     |
-| Tracking issue        |                                                 |
+| Tracking issue        | [rust-lang/rust-project-goals#649]              |
 | Other tracking issues | https://github.com/rust-lang/cargo/issues/16565 |
 | Zulip channel         | N/A                                             |
 | [cargo] champion      | @weihanglo                                      |
+
 
 ## Summary
 

--- a/src/2026/stabilize-fls-releases.md
+++ b/src/2026/stabilize-fls-releases.md
@@ -3,7 +3,7 @@
 | Metadata         |                                                                                                                |
 | :--              | :--                                                                                                            |
 | Point of contact | @PLeVasseur                                                                                                    |
-| Status           | Proposed                                                                                                       |
+| Status           | Accepted                                                                                                       |
 | What and why     | Predictable FLS releases within six weeks of each Rust stable release, so safety assessors have a current spec |
 | Roadmap          | Safety-Critical Rust                                                                                           |
 | Tracking issue   | [rust-lang/rust-project-goals#651]                                                                             |

--- a/src/2026/stabilize-fls-releases.md
+++ b/src/2026/stabilize-fls-releases.md
@@ -1,14 +1,15 @@
 # Stabilize FLS Release Cadence
 
-| Metadata         |                                    |
-| :--------------- | ---------------------------------- |
-| Point of contact | @PLeVasseur                        |
-| Status           | Proposed                           |
+| Metadata         |                                                                                                                |
+| :--              | :--                                                                                                            |
+| Point of contact | @PLeVasseur                                                                                                    |
+| Status           | Proposed                                                                                                       |
 | What and why     | Predictable FLS releases within six weeks of each Rust stable release, so safety assessors have a current spec |
-| Roadmap          | Safety-Critical Rust               |
-| Tracking issue   |                                    |
-| Zulip channel    | [#t-lang/fls](https://rust-lang.zulipchat.com/#narrow/channel/520710-t-lang.2Ffls) |
-| [fls] champion   | @PLeVasseur                        |
+| Roadmap          | Safety-Critical Rust                                                                                           |
+| Tracking issue   | [rust-lang/rust-project-goals#651]                                                                             |
+| Zulip channel    | [#t-lang/fls](https://rust-lang.zulipchat.com/#narrow/channel/520710-t-lang.2Ffls)                             |
+| [fls] champion   | @PLeVasseur                                                                                                    |
+
 
 ## Summary
 

--- a/src/2026/stabilize-never-type.md
+++ b/src/2026/stabilize-never-type.md
@@ -3,7 +3,7 @@
 | Metadata                |                                                |
 | :--                     | :--                                            |
 | Point of contact        | @WaffleLapkin                                  |
-| Status                  | Proposed                                       |
+| Status                  | Accepted                                       |
 | Tracking issue          | [rust-lang/rust-project-goals#653]             |
 | Other Tracking issue(s) | https://github.com/rust-lang/rust/issues/35121 |
 | Highlight               | Try, never, extern types                       |

--- a/src/2026/stabilize-never-type.md
+++ b/src/2026/stabilize-never-type.md
@@ -5,7 +5,7 @@
 | Point of contact        | @WaffleLapkin                                  |
 | Status                  | Accepted                                       |
 | Tracking issue          | [rust-lang/rust-project-goals#653]             |
-| Other Tracking issue(s) | https://github.com/rust-lang/rust/issues/35121 |
+| Other tracking issues | https://github.com/rust-lang/rust/issues/35121 |
 | Highlight               | Try, never, extern types                       |
 | Zulip channel           | N/A                                            |
 

--- a/src/2026/stabilize-never-type.md
+++ b/src/2026/stabilize-never-type.md
@@ -1,13 +1,14 @@
 # Stabilize never type (`!`)
 
-| Metadata                  |                                                                                  |
-| :------------------------ | -------------------------------------------------------------------------------- |
-| Point of contact          | @WaffleLapkin                                                                    |
-| Status                    | Proposed                                                                         |
-| Tracking issue            |                                                                                  |
-| Other Tracking issue(s)   | https://github.com/rust-lang/rust/issues/35121                                   |
-| Highlight                 | Try, never, extern types                                                         |
-| Zulip channel             | N/A                                                                              |
+| Metadata                |                                                |
+| :--                     | :--                                            |
+| Point of contact        | @WaffleLapkin                                  |
+| Status                  | Proposed                                       |
+| Tracking issue          | [rust-lang/rust-project-goals#653]             |
+| Other Tracking issue(s) | https://github.com/rust-lang/rust/issues/35121 |
+| Highlight               | Try, never, extern types                       |
+| Zulip channel           | N/A                                            |
+
 
 ## Summary
 

--- a/src/2026/stabilize-try.md
+++ b/src/2026/stabilize-try.md
@@ -3,7 +3,7 @@
 | Metadata              |                                    |
 | :--                   | :--                                |
 | Point of contact      | @tmandry                           |
-| Status                | Proposed                           |
+| Status                | Accepted                           |
 | Needs                 | Funding                            |
 | Other tracking issues | rust-lang/rust#84277               |
 | Zulip channel         | N/A                                |

--- a/src/2026/stabilize-try.md
+++ b/src/2026/stabilize-try.md
@@ -1,15 +1,17 @@
 # Stabilize the Try trait
 
-| Metadata              |                      |
-|:----------------------|----------------------|
-| Point of contact      | @tmandry             |
-| Status                | Proposed             |
-| Needs                 | Funding              |
-| Other tracking issues | rust-lang/rust#84277 |
-| Zulip channel         | N/A                  |
-| Highlight             | Try, never, extern types |
-| [lang] champion       | @tmandry             |
-| [libs-api] champion   | @Amanieu             |
+| Metadata              |                                    |
+| :--                   | :--                                |
+| Point of contact      | @tmandry                           |
+| Status                | Proposed                           |
+| Needs                 | Funding                            |
+| Other tracking issues | rust-lang/rust#84277               |
+| Zulip channel         | N/A                                |
+| Highlight             | Try, never, extern types           |
+| [lang] champion       | @tmandry                           |
+| [libs-api] champion   | @Amanieu                           |
+| Tracking issue        | [rust-lang/rust-project-goals#654] |
+
 
 ## Summary
 

--- a/src/2026/stabilizing-f16.md
+++ b/src/2026/stabilizing-f16.md
@@ -3,7 +3,7 @@
 | Metadata              |                                                 |
 | :--                   | :--                                             |
 | Point of contact      | @folkertdev                                     |
-| Status                | Proposed                                        |
+| Status                | Accepted                                        |
 | Tracking issue        | [rust-lang/rust-project-goals#655]              |
 | Other tracking issues | https://github.com/rust-lang/rust/issues/116909 |
 | Zulip channel         | N/A                                             |

--- a/src/2026/stabilizing-f16.md
+++ b/src/2026/stabilizing-f16.md
@@ -1,13 +1,14 @@
 # Stabilizing `f16`
 
-| Metadata         |                                                                                  |
-| :--------------- | -------------------------------------------------------------------------------- |
-| Point of contact | @folkertdev                                   |
-| Status           | Proposed                                                                         |
-| Tracking issue   |    |
+| Metadata              |                                                 |
+| :--                   | :--                                             |
+| Point of contact      | @folkertdev                                     |
+| Status                | Proposed                                        |
+| Tracking issue        | [rust-lang/rust-project-goals#655]              |
 | Other tracking issues | https://github.com/rust-lang/rust/issues/116909 |
-| Zulip channel    | N/A  |
-| Needs | Funding |
+| Zulip channel         | N/A                                             |
+| Needs                 | Funding                                         |
+
 
 ## Summary
 

--- a/src/2026/supertrait-auto-impl.md
+++ b/src/2026/supertrait-auto-impl.md
@@ -1,16 +1,17 @@
 # Implement Supertrait `auto impl`
 
-| Metadata              |                           |
-|:----------------------|---------------------------|
-| Point of contact      | @dingxiangfei2009         |
-| Status                | Proposed                  |
+| Metadata              |                                                                                                          |
+| :--                   | :--                                                                                                      |
+| Point of contact      | @dingxiangfei2009                                                                                        |
+| Status                | Proposed                                                                                                 |
 | What and why          | Automatically implement supertraits when a subtrait is implemented, enabling trait hierarchy refactoring |
-| Roadmap               | Beyond the `&` |
-| Roadmap               | Rust for Linux            |
-| [lang] champion       | @cramertj                 |
-| Tracking issue        |                           |
-| Other tracking issues | rust-lang/rust#149556     |
-| Zulip channel         | N/A                       |
+| Roadmap               | Beyond the `&`                                                                                           |
+| Roadmap               | Rust for Linux                                                                                           |
+| [lang] champion       | @cramertj                                                                                                |
+| Tracking issue        | [rust-lang/rust-project-goals#636]                                                                       |
+| Other tracking issues | rust-lang/rust#149556                                                                                    |
+| Zulip channel         | N/A                                                                                                      |
+
 
 ## Summary
 

--- a/src/2026/supertrait-auto-impl.md
+++ b/src/2026/supertrait-auto-impl.md
@@ -3,7 +3,7 @@
 | Metadata              |                                                                                                          |
 | :--                   | :--                                                                                                      |
 | Point of contact      | @dingxiangfei2009                                                                                        |
-| Status                | Proposed                                                                                                 |
+| Status                | Accepted                                                                                                 |
 | What and why          | Automatically implement supertraits when a subtrait is implemented, enabling trait hierarchy refactoring |
 | Roadmap               | Beyond the `&`                                                                                           |
 | Roadmap               | Rust for Linux                                                                                           |

--- a/src/2026/tail-call-loop-match.md
+++ b/src/2026/tail-call-loop-match.md
@@ -3,7 +3,7 @@
 | Metadata              |                                                                                                  |
 | :--                   | :--                                                                                              |
 | Point of contact      | @folkertdev                                                                                      |
-| Status                | Proposed                                                                                         |
+| Status                | Accepted                                                                                         |
 | Tracking issue        | [rust-lang/rust-project-goals#634]                                                               |
 | Other tracking issues | https://github.com/rust-lang/rust/issues/112788, https://github.com/rust-lang/rust/issues/132306 |
 | Zulip channel         |                                                                                                  |

--- a/src/2026/tail-call-loop-match.md
+++ b/src/2026/tail-call-loop-match.md
@@ -1,14 +1,15 @@
 # Explicit tail calls & `loop_match` 
 
-| Metadata              |                                                                                                         |
-| :-------------------- | ------------------------------------------------------------------------------------------------------ |
-| Point of contact      | @folkertdev                                                                                               |
-| Status                | Proposed                                                                                                   |
-| Tracking issue        |                                                                                                          |
+| Metadata              |                                                                                                  |
+| :--                   | :--                                                                                              |
+| Point of contact      | @folkertdev                                                                                      |
+| Status                | Proposed                                                                                         |
+| Tracking issue        | [rust-lang/rust-project-goals#634]                                                               |
 | Other tracking issues | https://github.com/rust-lang/rust/issues/112788, https://github.com/rust-lang/rust/issues/132306 |
-| Zulip channel         |                                                                                                          |
-| Needs | Funding |
-| [lang] champion | @scottmcm |
+| Zulip channel         |                                                                                                  |
+| Needs                 | Funding                                                                                          |
+| [lang] champion       | @scottmcm                                                                                        |
+
 
 ## Summary
 

--- a/src/2026/typesystem-docs.md
+++ b/src/2026/typesystem-docs.md
@@ -3,7 +3,7 @@
 | Metadata              |                                    |
 |:----------------------|:-----------------------------------|
 | Point of contact      | @BoxyUwU                           |
-| Status                | Proposed                           |
+| Status                | Accepted                           |
 | Tracking issue        | [rust-lang/rust-project-goals#405] |
 | Other tracking issues | [rustc-dev-guide#2663]             |
 | Zulip channel         | [#t-compiler/rustc-dev-guide]                            |

--- a/src/2026/unsafe-fields.md
+++ b/src/2026/unsafe-fields.md
@@ -4,7 +4,7 @@
 | :--                | :--                                                                                       |
 | Point of contact   | @jswrenn                                                                                  |
 | [lang] champion    | @nikomatsakis                                                                             |
-| Status             | Proposed                                                                                  |
+| Status             | Accepted                                                                                  |
 | Tracking issue     | [rust-lang/rust-project-goals#273]                                                        |
 | Zulip channel      | https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/unsafe.20fields.20RFC |
 

--- a/src/2026/user-research-team.md
+++ b/src/2026/user-research-team.md
@@ -1,11 +1,12 @@
 # Establish a User Research Team
 
 | Metadata         |                                    |
-| :--------------- | ---------------------------------- |
+| :--              | :--                                |
 | Point of contact | @nikomatsakis                      |
 | Status           | Proposed                           |
-| Tracking issue   |                                    |
+| Tracking issue   | [rust-lang/rust-project-goals#632] |
 | Zulip channel    | [#vision-doc-2025][channel]        |
+
 
 ## Summary
 

--- a/src/2026/user-research-team.md
+++ b/src/2026/user-research-team.md
@@ -3,7 +3,7 @@
 | Metadata         |                                    |
 | :--              | :--                                |
 | Point of contact | @nikomatsakis                      |
-| Status           | Proposed                           |
+| Status           | Accepted                           |
 | Tracking issue   | [rust-lang/rust-project-goals#632] |
 | Zulip channel    | [#vision-doc-2025][channel]        |
 

--- a/src/2026/wasm-components.md
+++ b/src/2026/wasm-components.md
@@ -1,12 +1,13 @@
 # Wasm Components
 
-| Metadata            |              |
-|:--------------------|--------------|
-| Point of contact    | @yoshuawuyts |
-| Status              | Proposed     |
-| Tracking issue      |              |
-| Zulip channel       | N/A          |
-| [compiler] champion | @WesleyWiser |
+| Metadata            |                                    |
+| :--                 | :--                                |
+| Point of contact    | @yoshuawuyts                       |
+| Status              | Proposed                           |
+| Tracking issue      | [rust-lang/rust-project-goals#656] |
+| Zulip channel       | N/A                                |
+| [compiler] champion | @WesleyWiser                       |
+
 
 ## Summary
 

--- a/src/2026/wasm-components.md
+++ b/src/2026/wasm-components.md
@@ -3,7 +3,7 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @yoshuawuyts                       |
-| Status              | Proposed                           |
+| Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#656] |
 | Zulip channel       | N/A                                |
 | [compiler] champion | @WesleyWiser                       |


### PR DESCRIPTION
This adds tracking issues links to new goals and marks every `Proposed` as `Accepted`.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/arbitrary-self-types.md)