### PR TITLE
Change manually-drop-attr point of contact

### DIFF
--- a/src/2026/manually-drop-attr.md
+++ b/src/2026/manually-drop-attr.md
@@ -2,7 +2,7 @@
 
 | Metadata            |                                    |
 | :--                 | :--                                |
-| Point of contact    | @thunderseethe                     |
+| Point of contact    | @JayanAXHF                         |
 | Status              | Accepted                           |
 | Needs               | Funding                            |
 | Tracking issue      | [rust-lang/rust-project-goals#628] |


### PR DESCRIPTION
@JayanAXHF asked me to make him the point of contact as he owns all the work. I checked with @thunderseethe and he's fine with it.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/manually-drop-attr.md)