### PR TITLE
Corrections to funding status

### DIFF
--- a/src/2026/async-statemachine-optimisation.md
+++ b/src/2026/async-statemachine-optimisation.md
@@ -89,7 +89,7 @@ I've got 4 optimisations on my list so far. You can see them in the work items a
 
 | Purpose | Cost | Status |
 |---------|------|--------|
-| Contributor | TBD | 💬 Under discussion |
+| Contributor | $50,000 | 💬 Under discussion |
 
 ## Frequently asked questions
 

--- a/src/2026/improve-cg_clif-performance.md
+++ b/src/2026/improve-cg_clif-performance.md
@@ -66,6 +66,6 @@ We additionally want to fix several long-standing bugs that limit `rustc_codegen
 
 | Purpose | Cost | Status |
 |---------|------|--------|
-| Contributor | $75,000 | ✅ Finalized |
+| Contributor | $75,000 | 🔍 Looking |
 
 ## Frequently asked questions

--- a/src/2026/stabilizing-f16.md
+++ b/src/2026/stabilizing-f16.md
@@ -48,7 +48,7 @@ With @tgross35 as the dedicated reviewer, the asks of the teams are limited.
 
 | Purpose | Cost | Status |
 |---------|------|--------|
-| Contributor | $25,000 | ✅ Finalized |
+| Contributor | $25,000 | 🔍 Looking |
 
 ## Frequently asked questions
 

--- a/src/2026/tail-call-loop-match.md
+++ b/src/2026/tail-call-loop-match.md
@@ -48,7 +48,7 @@ In light of these design issues, we'd also like to continue development of `loop
 
 | Purpose | Cost | Status |
 |---------|------|--------|
-| Contributor | $25,000 | ✅ Finalized |
+| Contributor | $25,000 | 💬 Under discussion |
 
 ## Frequently asked questions
 


### PR DESCRIPTION
Corrections to the funding status of four project goals by Tweede golf and Trifecta Tech team members.

cc @nikomatsakis, @diondokter, @folkertdev, @bjorn3 

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/tail-call-loop-match.md)