### PR TITLE
expand funding table information

### DIFF
--- a/crates/mdbook-goals/src/goal_preprocessor.rs
+++ b/crates/mdbook-goals/src/goal_preprocessor.rs
@@ -215,6 +215,15 @@ impl<'c> GoalPreprocessorWithContext<'c> {
         // Handle grouped funding table
         self.replace_funding_table_grouped(chapter)?;
 
+        // Handle funding table grouped by goal (alias for grouped)
+        self.replace_funding_table_grouped_by_goal(chapter)?;
+
+        // Handle funding table grouped by POC
+        self.replace_funding_table_grouped_by_poc(chapter)?;
+
+        // Handle funding legend
+        self.replace_funding_legend(chapter)?;
+
         Ok(())
     }
 
@@ -484,6 +493,66 @@ impl<'c> GoalPreprocessorWithContext<'c> {
 
         let roadmap_refs: Vec<&goal::RoadmapDocument> = roadmaps.iter().collect();
         let output = goal::format_funding_table_grouped(&filtered_goals, &roadmap_refs);
+        chapter.content.replace_range(range, &output);
+        Ok(())
+    }
+
+    fn replace_funding_table_grouped_by_goal(
+        &mut self,
+        chapter: &mut Chapter,
+    ) -> anyhow::Result<()> {
+        let Some(m) = re::FUNDING_TABLE_GROUPED_BY_GOAL.find(&chapter.content) else {
+            return Ok(());
+        };
+        let range = m.range();
+
+        let chapter_path = chapter_path(chapter, "(((FUNDING TABLE GROUPED BY GOAL)))")?;
+        let goals = self.goal_documents(chapter_path)?;
+        let roadmaps = self.roadmap_documents(chapter_path)?;
+
+        let mut filtered_goals: Vec<&GoalDocument> = goals
+            .iter()
+            .filter(|g| g.metadata.status.content.is_not_not_accepted() && g.needs_funding())
+            .collect();
+
+        filtered_goals.sort_by_key(|g| &g.metadata.title);
+
+        let roadmap_refs: Vec<&goal::RoadmapDocument> = roadmaps.iter().collect();
+        let output = goal::format_funding_table_grouped(&filtered_goals, &roadmap_refs);
+        chapter.content.replace_range(range, &output);
+        Ok(())
+    }
+
+    fn replace_funding_table_grouped_by_poc(
+        &mut self,
+        chapter: &mut Chapter,
+    ) -> anyhow::Result<()> {
+        let Some(m) = re::FUNDING_TABLE_GROUPED_BY_POC.find(&chapter.content) else {
+            return Ok(());
+        };
+        let range = m.range();
+
+        let chapter_path = chapter_path(chapter, "(((FUNDING TABLE GROUPED BY POC)))")?;
+        let goals = self.goal_documents(chapter_path)?;
+
+        let mut filtered_goals: Vec<&GoalDocument> = goals
+            .iter()
+            .filter(|g| g.metadata.status.content.is_not_not_accepted() && g.needs_funding())
+            .collect();
+
+        filtered_goals.sort_by_key(|g| &g.metadata.title);
+
+        let output = goal::format_funding_table_grouped_by_poc(&filtered_goals);
+        chapter.content.replace_range(range, &output);
+        Ok(())
+    }
+
+    fn replace_funding_legend(&mut self, chapter: &mut Chapter) -> anyhow::Result<()> {
+        let Some(m) = re::FUNDING_LEGEND.find(&chapter.content) else {
+            return Ok(());
+        };
+        let range = m.range();
+        let output = goal::format_funding_legend();
         chapter.content.replace_range(range, &output);
         Ok(())
     }

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -21,14 +21,19 @@ pub enum FundingCost {
     Usd(u64),
     /// The cost is not yet determined.
     Tbd,
+    /// The cost is undisclosed or not applicable.
+    Undisclosed,
 }
 
 impl FundingCost {
-    /// Parse a cost string like "$25,000", "$75K", "$1.5M", or "TBD".
+    /// Parse a cost string like "$25,000", "$75K", "$1.5M", "TBD", or "-".
     pub fn parse(s: &str) -> Option<Self> {
         let s = s.trim();
         if s.eq_ignore_ascii_case("TBD") {
             return Some(FundingCost::Tbd);
+        }
+        if s == "-" {
+            return Some(FundingCost::Undisclosed);
         }
         let s = s.strip_prefix('$')?;
         let s = s.replace(',', "");
@@ -45,10 +50,11 @@ impl FundingCost {
         }
     }
 
-    /// Format as a display string (e.g., "$75,000" or "TBD").
+    /// Format as a display string (e.g., "$75,000", "TBD", or "-").
     pub fn display(&self) -> String {
         match self {
             FundingCost::Tbd => "TBD".to_string(),
+            FundingCost::Undisclosed => "-".to_string(),
             FundingCost::Usd(amount) => format!("${}", format_with_commas(*amount)),
         }
     }
@@ -71,6 +77,7 @@ pub fn sum_funding_costs(costs: &[FundingCost]) -> Option<FundingCost> {
     let mut total: u64 = 0;
     let mut any_known = false;
     let mut any_tbd = false;
+    let mut any_undisclosed = false;
     for cost in costs {
         match cost {
             FundingCost::Usd(n) => {
@@ -80,23 +87,121 @@ pub fn sum_funding_costs(costs: &[FundingCost]) -> Option<FundingCost> {
             FundingCost::Tbd => {
                 any_tbd = true;
             }
+            FundingCost::Undisclosed => {
+                any_undisclosed = true;
+            }
         }
     }
-    if !any_known && any_tbd {
-        Some(FundingCost::Tbd)
-    } else if any_known {
+    if any_known {
         Some(FundingCost::Usd(total))
+    } else if any_tbd {
+        Some(FundingCost::Tbd)
+    } else if any_undisclosed {
+        Some(FundingCost::Undisclosed)
     } else {
         None
     }
 }
 
-/// A single row from the `## Funding` section's `| Purpose | Cost | Status |` table.
+/// The funding status of a single item or an entire goal.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FundingStatus {
+    /// Not yet funded.
+    No,
+    /// Partially funded (optionally by a named sponsor).
+    Partial(Option<String>),
+    /// Fully funded by the named sponsor(s).
+    Funded(Option<String>),
+}
+
+impl FundingStatus {
+    /// Parse a funded value: "No", "Partial", "Partial by X", "Yes", or "By X".
+    pub fn parse(s: &str) -> Self {
+        let s = s.trim();
+        if s.eq_ignore_ascii_case("no") {
+            FundingStatus::No
+        } else if s.eq_ignore_ascii_case("partial") {
+            FundingStatus::Partial(None)
+        } else if let Some(rest) = s.strip_prefix("Partial by ").or_else(|| s.strip_prefix("partial by ")) {
+            FundingStatus::Partial(Some(rest.trim().to_string()))
+        } else if s.eq_ignore_ascii_case("yes") {
+            FundingStatus::Funded(None)
+        } else if let Some(rest) = s.strip_prefix("By ").or_else(|| s.strip_prefix("by ")) {
+            FundingStatus::Funded(Some(rest.trim().to_string()))
+        } else {
+            FundingStatus::No
+        }
+    }
+
+    /// The status emoji only.
+    pub fn emoji(&self) -> &'static str {
+        match self {
+            FundingStatus::No => "\u{1f7e5}",
+            FundingStatus::Partial(_) => "\u{1f7e1}",
+            FundingStatus::Funded(_) => "\u{2705}",
+        }
+    }
+
+    /// Display as emoji + label (for per-goal section rendering).
+    pub fn display(&self) -> &'static str {
+        match self {
+            FundingStatus::No => "\u{25cb} No",
+            FundingStatus::Partial(_) => "\u{25d1} Partial",
+            FundingStatus::Funded(_) => "\u{2713} Yes",
+        }
+    }
+
+    /// Extract the sponsor name, if any.
+    pub fn sponsor(&self) -> Option<&str> {
+        match self {
+            FundingStatus::No => None,
+            FundingStatus::Partial(s) => s.as_deref(),
+            FundingStatus::Funded(s) => s.as_deref(),
+        }
+    }
+
+    /// Is this at least partially funded?
+    fn is_at_least_partial(&self) -> bool {
+        !matches!(self, FundingStatus::No)
+    }
+
+    /// Is this fully funded?
+    fn is_funded(&self) -> bool {
+        matches!(self, FundingStatus::Funded(_))
+    }
+
+    /// Aggregate multiple item statuses into a single goal-level status.
+    pub fn aggregate(statuses: &[FundingStatus]) -> FundingStatus {
+        if statuses.is_empty() {
+            return FundingStatus::No;
+        }
+        // Collect all sponsors
+        let sponsors: Vec<&str> = statuses.iter().filter_map(|s| s.sponsor()).collect();
+        let combined_sponsor = if sponsors.is_empty() {
+            None
+        } else {
+            Some(sponsors.join(", "))
+        };
+
+        let all_funded = statuses.iter().all(|s| s.is_funded());
+        let any_funded = statuses.iter().any(|s| s.is_at_least_partial());
+        if all_funded {
+            FundingStatus::Funded(combined_sponsor)
+        } else if any_funded {
+            FundingStatus::Partial(combined_sponsor)
+        } else {
+            FundingStatus::No
+        }
+    }
+}
+
+/// A single row from the `## Funding` section's `| Purpose | Cost | Funded |` table.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FundingItem {
     pub purpose: String,
     pub cost: FundingCost,
-    pub status: String,
+    pub status: FundingStatus,
+    pub sponsors: Option<String>,
 }
 
 /// A single row from the `## Help wanted` section's `| Task | Experience level | Time investment |` table.
@@ -234,6 +339,10 @@ pub struct Metadata {
 
     /// Optional "Timespan" override (e.g. "2026–2027"). Defaults to the milestone directory name.
     pub timespan: Option<String>,
+
+    /// Optional funding point of contact (freeform markdown).
+    /// Defaults to the Rust Funding team link when absent.
+    pub funding_poc: Option<String>,
 }
 
 impl Metadata {
@@ -724,6 +833,35 @@ impl GoalDocument {
         !self.funding.is_empty()
     }
 
+    /// Returns the aggregate funding status for this goal.
+    pub fn funding_status(&self) -> FundingStatus {
+        let statuses: Vec<FundingStatus> = self.funding.iter().map(|f| f.status.clone()).collect();
+        FundingStatus::aggregate(&statuses)
+    }
+
+    /// Returns the funding point of contact for this goal, defaulting to the Rust Funding team.
+    pub fn funding_point_of_contact(&self) -> &str {
+        const DEFAULT_FUNDING_POC: &str =
+            "[Funding team](https://rust-lang.org/governance/teams/launching-pad/#team-funding)";
+        self.metadata
+            .funding_poc
+            .as_deref()
+            .unwrap_or(DEFAULT_FUNDING_POC)
+    }
+
+    pub fn sponsors_display(&self) -> String {
+        let sponsors: Vec<&str> = self
+            .funding
+            .iter()
+            .filter_map(|f| f.sponsors.as_deref())
+            .collect();
+        if sponsors.is_empty() {
+            String::new()
+        } else {
+            format!("\u{1f64f} {}", sponsors.join(", "))
+        }
+    }
+
     /// True if this goal needs a contributor (has a `## Help wanted` section).
     pub fn needs_contributor(&self) -> bool {
         !self.help_wanted.is_empty()
@@ -973,11 +1111,11 @@ pub fn format_highlight_goal_sections(
 }
 
 /// Format a summary table of goals needing funding.
-/// Columns: Goal (linked to page#funding), Cost, Status, What and why.
+/// Columns: status emoji, Goal, Contact, Sponsor, What and why.
 pub fn format_funding_table(goals: &[&GoalDocument]) -> String {
     let mut output = String::new();
-    output.push_str("| Goal | Cost | Status | What and why |\n");
-    output.push_str("| --- | --- | --- | --- |\n");
+    output.push_str("| | Goal | Contact | Funding POC | Sponsor(s) |\n");
+    output.push_str("| --- | --- | --- | --- | --- |\n");
     for goal in goals {
         format_funding_table_row(&mut output, goal);
     }
@@ -992,11 +1130,10 @@ pub fn format_funding_table_grouped(
     roadmaps: &[&RoadmapDocument],
 ) -> String {
     let mut output = String::new();
-    output.push_str("| Goal | Cost | Status | What and why |\n");
-    output.push_str("| --- | --- | --- | --- |\n");
+    output.push_str("| | Goal | Contact | Funding POC | Sponsor(s) |\n");
+    output.push_str("| --- | --- | --- | --- | --- |\n");
 
     let mut used: Vec<bool> = vec![false; goals.len()];
-    let mut all_costs: Vec<FundingCost> = vec![];
 
     // Sort roadmaps alphabetically by short title
     let mut sorted_roadmaps: Vec<&&RoadmapDocument> = roadmaps.iter().collect();
@@ -1015,25 +1152,15 @@ pub fn format_funding_table_grouped(
             continue;
         }
 
-        // Collect costs for subtotal
-        let group_costs: Vec<FundingCost> = matching
-            .iter()
-            .flat_map(|&i| goals[i].funding.iter().map(|f| f.cost.clone()))
-            .collect();
-        let subtotal = sum_funding_costs(&group_costs);
-        let subtotal_str = subtotal.map(|c| c.display()).unwrap_or_default();
-
-        // Emit roadmap header row with subtotal
+        // Emit roadmap header row
         output.push_str(&format!(
-            "| **[{}]({})** | **{}** | | |\n",
+            "| - | **[{}]({})** | -- | -- | -- |\n",
             theme,
             roadmap.link_path.display(),
-            subtotal_str,
         ));
 
         for i in &matching {
             used[*i] = true;
-            all_costs.extend(goals[*i].funding.iter().map(|f| f.cost.clone()));
             format_funding_table_row(&mut output, goals[*i]);
         }
     }
@@ -1041,26 +1168,47 @@ pub fn format_funding_table_grouped(
     // Emit "Other goals" for anything not in a roadmap
     let other: Vec<usize> = (0..goals.len()).filter(|i| !used[*i]).collect();
     if !other.is_empty() {
-        let group_costs: Vec<FundingCost> = other
-            .iter()
-            .flat_map(|&i| goals[i].funding.iter().map(|f| f.cost.clone()))
-            .collect();
-        let subtotal = sum_funding_costs(&group_costs);
-        let subtotal_str = subtotal.map(|c| c.display()).unwrap_or_default();
-
-        output.push_str(&format!("| **Other goals** | **{}** | | |\n", subtotal_str));
+        output.push_str("| - | **Other goals** | -- | -- | -- |\n");
         for i in &other {
-            all_costs.extend(goals[*i].funding.iter().map(|f| f.cost.clone()));
             format_funding_table_row(&mut output, goals[*i]);
         }
     }
 
-    // Grand total
-    if let Some(total) = sum_funding_costs(&all_costs) {
-        output.push_str(&format!("| **Total** | **{}** | | |\n", total.display()));
+    output
+}
+
+/// Format a summary table of goals needing funding, grouped by funding point of contact.
+/// Each distinct POC gets a bold header row. Goals are listed underneath their POC.
+pub fn format_funding_table_grouped_by_poc(goals: &[&GoalDocument]) -> String {
+    let mut output = String::new();
+    output.push_str("| | Goal | Contact | Funding POC | Sponsor(s) |\n");
+    output.push_str("| --- | --- | --- | --- | --- |\n");
+
+    // Group goals by their funding POC
+    let mut by_poc: BTreeMap<String, Vec<&GoalDocument>> = BTreeMap::new();
+    for goal in goals {
+        let poc = goal.funding_point_of_contact().to_string();
+        by_poc.entry(poc).or_default().push(goal);
+    }
+
+    for (poc, poc_goals) in &by_poc {
+        output.push_str(&format!("| - | **{}** | -- | -- | -- |\n", poc));
+
+        for goal in poc_goals {
+            format_funding_table_row(&mut output, goal);
+        }
     }
 
     output
+}
+
+pub fn format_funding_legend() -> String {
+    format!(
+        "| Legend | |\n| --- | --- |\n| {} | Seeking funding |\n| {} | Partially funded, could use more support |\n| {} | Good to go |\n",
+        FundingStatus::No.emoji(),
+        FundingStatus::Partial(None).emoji(),
+        FundingStatus::Funded(None).emoji(),
+    )
 }
 
 fn format_funding_table_row(output: &mut String, goal: &GoalDocument) {
@@ -1072,18 +1220,15 @@ fn format_funding_table_row(output: &mut String, goal: &GoalDocument) {
             .collect::<Vec<_>>(),
     );
     let cost_str = total.map(|c| c.display()).unwrap_or_default();
-    let status = goal
-        .funding
-        .first()
-        .map(|f| f.status.as_str())
-        .unwrap_or("");
+    let status = goal.funding_status();
     output.push_str(&format!(
-        "| [{}]({}#funding) | {} | {} | {} |\n",
+        "| {} | [{}]({}#funding) | {} | {} | {} |\n",
+        status.emoji(),
         *goal.metadata.title,
         goal.link_path.display(),
         cost_str,
-        status,
-        goal.what_and_why(),
+        goal.funding_point_of_contact(),
+        goal.sponsors_display(),
     ));
 }
 
@@ -1120,16 +1265,20 @@ pub fn format_funding_goal_sections(
         output.push_str(goal.summary.trim());
         output.push_str("\n\n");
 
-        // Render funding table
+        // Render funding contact and table
         if !goal.funding.is_empty() {
-            output.push_str("| Purpose | Cost | Status |\n");
+            output.push_str(&format!(
+                "**Contact:** {}\n\n",
+                goal.funding_point_of_contact()
+            ));
+            output.push_str("| Purpose | Cost | Funded |\n");
             output.push_str("|---------|------|--------|\n");
             for item in &goal.funding {
                 output.push_str(&format!(
                     "| {} | {} | {} |\n",
                     item.purpose,
                     item.cost.display(),
-                    item.status
+                    item.status.display()
                 ));
             }
             output.push('\n');
@@ -1526,6 +1675,18 @@ fn extract_metadata(sections: &[Section]) -> Result<Option<Metadata>> {
         .find(|row| row[0].content.trim().eq_ignore_ascii_case("Timespan"))
         .map(|row| row[1].to_string());
 
+    let funding_poc = first_table
+        .rows
+        .iter()
+        .find(|row| {
+            row[0]
+                .content
+                .trim()
+                .eq_ignore_ascii_case("Funding point of contact")
+        })
+        .map(|row| row[1].to_string())
+        .filter(|s| !s.trim().is_empty());
+
     Ok(Some(Metadata {
         title: title.clone(),
         short_title: if let Some(row) = short_title_row {
@@ -1543,6 +1704,7 @@ fn extract_metadata(sections: &[Section]) -> Result<Option<Metadata>> {
         needs,
         what_and_why,
         timespan,
+        funding_poc,
     }))
 }
 
@@ -1590,15 +1752,20 @@ fn extract_funding(sections: &[Section]) -> Result<Vec<FundingItem>> {
         return Ok(vec![]);
     };
 
-    expect_headers(table, &["Purpose", "Cost", "Status"])?;
+    expect_headers(table, &["Purpose", "Cost", "Funded", "Sponsor(s)"])?;
 
     let mut items = vec![];
     for row in &table.rows {
         let cost = FundingCost::parse(row[1].trim()).unwrap_or(FundingCost::Tbd);
+        let sponsors = {
+            let s = row[3].trim().to_string();
+            if s.is_empty() { None } else { Some(s) }
+        };
         items.push(FundingItem {
             purpose: row[0].to_string(),
             cost,
-            status: row[2].to_string(),
+            status: FundingStatus::parse(&row[2]),
+            sponsors,
         });
     }
     Ok(items)

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -1111,10 +1111,10 @@ pub fn format_highlight_goal_sections(
 }
 
 /// Format a summary table of goals needing funding.
-/// Columns: status emoji, Goal, Contact, Sponsor, What and why.
+/// Columns: status emoji, Goal, Cost, Sponsor.
 pub fn format_funding_table(goals: &[&GoalDocument]) -> String {
     let mut output = String::new();
-    output.push_str("| | Goal | Contact | Funding POC | Sponsor(s) |\n");
+    output.push_str("| | Goal | Cost | Funding POC | Sponsor(s) |\n");
     output.push_str("| --- | --- | --- | --- | --- |\n");
     for goal in goals {
         format_funding_table_row(&mut output, goal);
@@ -1130,7 +1130,7 @@ pub fn format_funding_table_grouped(
     roadmaps: &[&RoadmapDocument],
 ) -> String {
     let mut output = String::new();
-    output.push_str("| | Goal | Contact | Funding POC | Sponsor(s) |\n");
+    output.push_str("| | Goal | Cost | Funding POC | Sponsor(s) |\n");
     output.push_str("| --- | --- | --- | --- | --- |\n");
 
     let mut used: Vec<bool> = vec![false; goals.len()];
@@ -1181,7 +1181,7 @@ pub fn format_funding_table_grouped(
 /// Each distinct POC gets a bold header row. Goals are listed underneath their POC.
 pub fn format_funding_table_grouped_by_poc(goals: &[&GoalDocument]) -> String {
     let mut output = String::new();
-    output.push_str("| | Goal | Contact | Funding POC | Sponsor(s) |\n");
+    output.push_str("| | Goal | Cost | Funding POC | Sponsor(s) |\n");
     output.push_str("| --- | --- | --- | --- | --- |\n");
 
     // Group goals by their funding POC

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -21,18 +21,18 @@ pub enum FundingCost {
     Usd(u64),
     /// The cost is not yet determined.
     Tbd,
-    /// The cost is undisclosed or not applicable.
+    /// The cost is undisclosed.
     Undisclosed,
 }
 
 impl FundingCost {
-    /// Parse a cost string like "$25,000", "$75K", "$1.5M", "TBD", or "-".
+    /// Parse a cost string like "$25,000", "$75K", "$1.5M", "TBD", or "Undisclosed".
     pub fn parse(s: &str) -> Option<Self> {
         let s = s.trim();
         if s.eq_ignore_ascii_case("TBD") {
             return Some(FundingCost::Tbd);
         }
-        if s == "-" {
+        if s.eq_ignore_ascii_case("Undisclosed") {
             return Some(FundingCost::Undisclosed);
         }
         let s = s.strip_prefix('$')?;
@@ -50,11 +50,11 @@ impl FundingCost {
         }
     }
 
-    /// Format as a display string (e.g., "$75,000", "TBD", or "-").
+    /// Format as a display string (e.g., "$75,000", "TBD", or "Ask Funding POC").
     pub fn display(&self) -> String {
         match self {
             FundingCost::Tbd => "TBD".to_string(),
-            FundingCost::Undisclosed => "-".to_string(),
+            FundingCost::Undisclosed => "Ask Funding POC".to_string(),
             FundingCost::Usd(amount) => format!("${}", format_with_commas(*amount)),
         }
     }

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -21,19 +21,19 @@ pub enum FundingCost {
     Usd(u64),
     /// The cost is not yet determined.
     Tbd,
-    /// The cost is undisclosed.
-    Undisclosed,
+    /// Ask the Funding contact about the cost.
+    Ask,
 }
 
 impl FundingCost {
-    /// Parse a cost string like "$25,000", "$75K", "$1.5M", "TBD", or "Undisclosed".
+    /// Parse a cost string like "$25,000", "$75K", "$1.5M", "TBD", or "Ask".
     pub fn parse(s: &str) -> Option<Self> {
         let s = s.trim();
         if s.eq_ignore_ascii_case("TBD") {
             return Some(FundingCost::Tbd);
         }
-        if s.eq_ignore_ascii_case("Undisclosed") {
-            return Some(FundingCost::Undisclosed);
+        if s.eq_ignore_ascii_case("Ask") {
+            return Some(FundingCost::Ask);
         }
         let s = s.strip_prefix('$')?;
         let s = s.replace(',', "");
@@ -50,11 +50,11 @@ impl FundingCost {
         }
     }
 
-    /// Format as a display string (e.g., "$75,000", "TBD", or "Ask Funding POC").
+    /// Format as a display string (e.g., "$75,000", "TBD", or "Ask").
     pub fn display(&self) -> String {
         match self {
             FundingCost::Tbd => "TBD".to_string(),
-            FundingCost::Undisclosed => "Ask Funding POC".to_string(),
+            FundingCost::Ask => "Ask".to_string(),
             FundingCost::Usd(amount) => format!("${}", format_with_commas(*amount)),
         }
     }
@@ -87,7 +87,7 @@ pub fn sum_funding_costs(costs: &[FundingCost]) -> Option<FundingCost> {
             FundingCost::Tbd => {
                 any_tbd = true;
             }
-            FundingCost::Undisclosed => {
+            FundingCost::Ask => {
                 any_undisclosed = true;
             }
         }
@@ -97,7 +97,7 @@ pub fn sum_funding_costs(costs: &[FundingCost]) -> Option<FundingCost> {
     } else if any_tbd {
         Some(FundingCost::Tbd)
     } else if any_undisclosed {
-        Some(FundingCost::Undisclosed)
+        Some(FundingCost::Ask)
     } else {
         None
     }
@@ -1114,7 +1114,7 @@ pub fn format_highlight_goal_sections(
 /// Columns: status emoji, Goal, Cost, Sponsor.
 pub fn format_funding_table(goals: &[&GoalDocument]) -> String {
     let mut output = String::new();
-    output.push_str("| | Goal | Cost | Funding POC | Sponsor(s) |\n");
+    output.push_str("| | Goal | Cost | Funding contact | Sponsor(s) |\n");
     output.push_str("| --- | --- | --- | --- | --- |\n");
     for goal in goals {
         format_funding_table_row(&mut output, goal);
@@ -1130,7 +1130,7 @@ pub fn format_funding_table_grouped(
     roadmaps: &[&RoadmapDocument],
 ) -> String {
     let mut output = String::new();
-    output.push_str("| | Goal | Cost | Funding POC | Sponsor(s) |\n");
+    output.push_str("| | Goal | Cost | Funding contact | Sponsor(s) |\n");
     output.push_str("| --- | --- | --- | --- | --- |\n");
 
     let mut used: Vec<bool> = vec![false; goals.len()];
@@ -1181,7 +1181,7 @@ pub fn format_funding_table_grouped(
 /// Each distinct POC gets a bold header row. Goals are listed underneath their POC.
 pub fn format_funding_table_grouped_by_poc(goals: &[&GoalDocument]) -> String {
     let mut output = String::new();
-    output.push_str("| | Goal | Cost | Funding POC | Sponsor(s) |\n");
+    output.push_str("| | Goal | Cost | Funding contact | Sponsor(s) |\n");
     output.push_str("| --- | --- | --- | --- | --- |\n");
 
     // Group goals by their funding POC

--- a/crates/rust-project-goals/src/goal.rs
+++ b/crates/rust-project-goals/src/goal.rs
@@ -124,7 +124,7 @@ impl FundingStatus {
             FundingStatus::Partial(None)
         } else if let Some(rest) = s.strip_prefix("Partial by ").or_else(|| s.strip_prefix("partial by ")) {
             FundingStatus::Partial(Some(rest.trim().to_string()))
-        } else if s.eq_ignore_ascii_case("yes") {
+        } else if s.eq_ignore_ascii_case("full") {
             FundingStatus::Funded(None)
         } else if let Some(rest) = s.strip_prefix("By ").or_else(|| s.strip_prefix("by ")) {
             FundingStatus::Funded(Some(rest.trim().to_string()))

--- a/crates/rust-project-goals/src/re.rs
+++ b/crates/rust-project-goals/src/re.rs
@@ -124,6 +124,24 @@ lazy_static! {
         Regex::new(r"\(\(\(FUNDING TABLE GROUPED\)\)\)").unwrap();
 }
 
+// Summary table of goals needing funding, grouped by roadmap (alias)
+lazy_static! {
+    pub static ref FUNDING_TABLE_GROUPED_BY_GOAL: Regex =
+        Regex::new(r"\(\(\(FUNDING TABLE GROUPED BY GOAL\)\)\)").unwrap();
+}
+
+// Summary table of goals needing funding, grouped by funding point of contact
+lazy_static! {
+    pub static ref FUNDING_TABLE_GROUPED_BY_POC: Regex =
+        Regex::new(r"\(\(\(FUNDING TABLE GROUPED BY POC\)\)\)").unwrap();
+}
+
+// Funding legend showing emoji meanings
+lazy_static! {
+    pub static ref FUNDING_LEGEND: Regex =
+        Regex::new(r"\(\(\(FUNDING LEGEND\)\)\)").unwrap();
+}
+
 // Roadmap goal rows (no headers) filtered by roadmap name.
 // Used inside manually authored markdown tables: `| (((ROADMAP ROWS: Theme))) |`
 lazy_static! {

--- a/src/2026/afidt-box.md
+++ b/src/2026/afidt-box.md
@@ -97,9 +97,9 @@ For more details and a broader look, see the [box, box, box][box-post] blog post
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | TBD | 🔍 Looking |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | TBD | No | |
 
 
 ## Frequently asked questions

--- a/src/2026/async-statemachine-optimisation.md
+++ b/src/2026/async-statemachine-optimisation.md
@@ -7,6 +7,7 @@
 | Tracking issue      | [rust-lang/rust-project-goals#623] |
 | Zulip channel       | N/A                                |
 | [compiler] champion | @eholk                             |
+| Funding point of contact | [Trifecta Tech Foundation](https://trifectatech.org/) |
 
 ## Summary
 
@@ -87,9 +88,9 @@ I've got 4 optimisations on my list so far. You can see them in the work items a
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | $50,000 | 💬 Under discussion |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | $50,000 | No | |
 
 ## Frequently asked questions
 

--- a/src/2026/async-statemachine-optimisation.md
+++ b/src/2026/async-statemachine-optimisation.md
@@ -7,7 +7,7 @@
 | Tracking issue      | [rust-lang/rust-project-goals#623] |
 | Zulip channel       | N/A                                |
 | [compiler] champion | @eholk                             |
-| Funding point of contact | [Trifecta Tech Foundation](https://trifectatech.org/) |
+| Funding point of contact | [Tweede golf](https://tweedegolf.nl/) |
 
 ## Summary
 

--- a/src/2026/expansion-time-evaluation.md
+++ b/src/2026/expansion-time-evaluation.md
@@ -67,9 +67,9 @@ We will prototype decoupling macro expansion from the monolithic resolver. This 
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | TBD | 🔍 Looking |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | TBD | No | |
 
 ## Frequently asked questions
 

--- a/src/2026/funding.md
+++ b/src/2026/funding.md
@@ -1,7 +1,13 @@
 # Looking for funding
 
-The goals below are looking for funding. If you might be interested in helping to fund a goal, please join the rust-lang Zulip and post a message in the [`#project-goals/2026-workshop`][channel] channel or write to the goals team at `goals-team@rust-lang.org`.
+The following goals below are looking for funding. Many goals have a point of contact but you can also work with the Rust Funding Team to interface (`funding@rust-lang.org`).
 
-[channel]: https://rust-lang.zulipchat.com/#narrow/channel/546987-project-goals.2F2026-workshop
+(((FUNDING LEGEND)))
 
-(((FUNDING TABLE GROUPED)))
+## By roadmap
+
+(((FUNDING TABLE GROUPED BY GOAL)))
+
+## By funding POC
+
+(((FUNDING TABLE GROUPED BY POC)))

--- a/src/2026/improve-cg_clif-performance.md
+++ b/src/2026/improve-cg_clif-performance.md
@@ -3,12 +3,12 @@
 | Metadata            |                                    |
 | :--                 | :--                                |
 | Point of contact    | @bjorn3                            |
+| Funding point of contact | [Tweede Golf](https://tweedegolf.nl/en) |
 | Status              | Accepted                           |
 | Tracking issue      | [rust-lang/rust-project-goals#639] |
 | Zulip channel       | N/A                                |
 | Roadmap             | Fast Builds                        |
 | [compiler] champion | @bjorn3                            |
-
 
 ## Summary
 
@@ -64,8 +64,8 @@ We additionally want to fix several long-standing bugs that limit `rustc_codegen
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | $75,000 | 🔍 Looking |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | $75,000 | No | |
 
 ## Frequently asked questions

--- a/src/2026/manually-drop-attr.md
+++ b/src/2026/manually-drop-attr.md
@@ -132,9 +132,9 @@ impl Destruct for UringState {
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | TBD | 💬 Under discussion |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | TBD | Partial | |
 
 ## Frequently asked questions
 

--- a/src/2026/next-solver.md
+++ b/src/2026/next-solver.md
@@ -65,8 +65,8 @@ Stabilize `-Znext-solver=globally` and rip out the old implementation
 
 | Purpose           | Cost | Funded | Sponsor(s)     |
 |-------------------|------|--------|----------------|
-| Core contribution | -    | Full   | Anon1, Anon2 |
-| Acceleration      | -    | No     |
+| Core contribution | Undisclosed | Full   | Anon1, Anon2 |
+| Acceleration      | Undisclosed | No     |
 
 ## Frequently asked questions
 

--- a/src/2026/next-solver.md
+++ b/src/2026/next-solver.md
@@ -65,8 +65,8 @@ Stabilize `-Znext-solver=globally` and rip out the old implementation
 
 | Purpose           | Cost | Funded | Sponsor(s)     |
 |-------------------|------|--------|----------------|
-| Core contribution | Undisclosed | Full   | Anon1, Anon2 |
-| Acceleration      | Undisclosed | No     |
+| Core contribution | Ask | Full   | Anon1, Anon2 |
+| Acceleration      | Ask | No     |
 
 ## Frequently asked questions
 

--- a/src/2026/next-solver.md
+++ b/src/2026/next-solver.md
@@ -13,6 +13,7 @@
 | Highlight             | Next-generation trait solver              |
 | [types] champion      | @lcnr                                     |
 | [lang] champion       | @nikomatsakis                             |
+| Funding point of contact | [Hexcat](https://hexcat.nl/) |
 
 [channel]: https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor
 
@@ -59,6 +60,13 @@ Stabilize `-Znext-solver=globally` and rip out the old implementation
 | ------- | ------------- | ------------------------------------------- |
 | [lang]  | Medium        | Stabilization decision for user facing changes |
 | [types] | Large         | Stabilization decision, ongoing review work |
+
+## Funding
+
+| Purpose           | Cost | Funded | Sponsor(s)     |
+|-------------------|------|--------|----------------|
+| Core contribution | -    | Yes    | Anon1, Anon2 |
+| Acceleration      | -    | No     |
 
 ## Frequently asked questions
 

--- a/src/2026/next-solver.md
+++ b/src/2026/next-solver.md
@@ -65,7 +65,7 @@ Stabilize `-Znext-solver=globally` and rip out the old implementation
 
 | Purpose           | Cost | Funded | Sponsor(s)     |
 |-------------------|------|--------|----------------|
-| Core contribution | -    | Yes    | Anon1, Anon2 |
+| Core contribution | -    | Full   | Anon1, Anon2 |
 | Acceleration      | -    | No     |
 
 ## Frequently asked questions

--- a/src/2026/specialization.md
+++ b/src/2026/specialization.md
@@ -55,8 +55,8 @@ Given that specialization is largely blocked on design work to address known sou
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | TBD | 💬 Under discussion |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | TBD | Partial | |
 
 ## Frequently asked questions

--- a/src/2026/stabilize-try.md
+++ b/src/2026/stabilize-try.md
@@ -114,8 +114,8 @@ Because there are open design questions that haven't yet been resolved, we shoul
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | TBD | 💬 Under discussion |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | TBD | Partial | |
 
 ## Frequently asked questions

--- a/src/2026/stabilizing-f16.md
+++ b/src/2026/stabilizing-f16.md
@@ -7,7 +7,7 @@
 | Tracking issue        | [rust-lang/rust-project-goals#655]              |
 | Other tracking issues | https://github.com/rust-lang/rust/issues/116909 |
 | Zulip channel         | N/A                                             |
-
+| Funding point of contact | [Trifecta Tech Foundation](https://trifectatech.org/) |
 
 ## Summary
 
@@ -46,9 +46,9 @@ With @tgross35 as the dedicated reviewer, the asks of the teams are limited.
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | $25,000 | 🔍 Looking |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | $25,000 | No | |
 
 ## Frequently asked questions
 

--- a/src/2026/tail-call-loop-match.md
+++ b/src/2026/tail-call-loop-match.md
@@ -8,7 +8,7 @@
 | Other tracking issues | https://github.com/rust-lang/rust/issues/112788, https://github.com/rust-lang/rust/issues/132306 |
 | Zulip channel         |                                                                                                  |
 | [lang] champion       | @scottmcm                                                                                        |
-
+| Funding point of contact | [Trifecta Tech Foundation](https://trifectatech.org/) |
 
 ## Summary
 
@@ -46,9 +46,9 @@ In light of these design issues, we'd also like to continue development of `loop
 
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor | $25,000 | 💬 Under discussion |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor | $25,000 | No | |
 
 ## Frequently asked questions
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -6,9 +6,8 @@
 
 - [Overview](./2026/README.md)
 - [Highlights](./2026/highlights.md)
-- [Help wanted](./2026/help-wanted.md)
-  - [Looking for contributors](./2026/contributors.md)
-  - [Looking for funding](./2026/funding.md)
+- [Looking to contribute?](./2026/contributors.md)
+- [Looking to fund?](./2026/funding.md)
 - [Roadmaps](./2026/roadmaps.md)
 - [Goals](./2026/goals.md)
 - [Frequently asked questions](./2026/faq.md)

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -104,11 +104,16 @@
 > describing what the funding would cover and the estimated cost.
 > The presence of this section signals that the goal is looking for financial support.
 > Delete this section if your goal does not need funding.
+>
+> If you have a specific funding point of contact (e.g., an organization that can
+> receive and administer funds), add a `Funding point of contact` row to the
+> metadata table at the top of this file. If omitted, it defaults to the
+> [Rust Funding team](https://rust-lang.org/governance/teams/launching-pad/#team-funding).
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| *e.g., Contributor (6 months, full-time)* | *e.g., $60,000* | 🔍 Looking |
-| *e.g., Maintenance* | *e.g., $10,000* | 🔍 Looking |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| *e.g., Contributor (6 months, full-time)* | *e.g., $60,000* | No | |
+| *e.g., Maintenance* | *e.g., $10,000* | No | |
 
 ## Frequently asked questions
 

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -115,6 +115,8 @@
 | *e.g., Contributor (6 months, full-time)* | *e.g., $60,000* | No | |
 | *e.g., Maintenance* | *e.g., $10,000* | No | |
 
+> If you don't know the expected cost, enter `TBD`. If you do, but prefer to not have it public on the internet, enter `Undisclosed` and the readers will be directed to contact the *Funding POC* to learn more.
+
 ## Frequently asked questions
 
 ### What do I do with this space?

--- a/src/TEMPLATE.md
+++ b/src/TEMPLATE.md
@@ -115,7 +115,7 @@
 | *e.g., Contributor (6 months, full-time)* | *e.g., $60,000* | No | |
 | *e.g., Maintenance* | *e.g., $10,000* | No | |
 
-> If you don't know the expected cost, enter `TBD`. If you do, but prefer to not have it public on the internet, enter `Undisclosed` and the readers will be directed to contact the *Funding POC* to learn more.
+> If you don't know the expected cost, enter `TBD`. If you do, but prefer to not have it public on the internet, enter `Ask` and the readers will be directed to ask the *Funding contact* about the cost.
 
 ## Frequently asked questions
 

--- a/src/about/goal-format.md
+++ b/src/about/goal-format.md
@@ -29,6 +29,7 @@ The recognized fields are:
 | **Roadmap** | No | The name of a roadmap theme this goal belongs to, e.g. `Rust for Linux`. Can appear multiple times if the goal spans several roadmaps. |
 | **Highlight** | No | A category name for the highlights page. Can appear multiple times. |
 | **Timespan** | No | Overrides the default goal period, e.g. `2026-2027` for multi-year goals. |
+| **Funding point of contact** | No | Freeform text (may include markdown links) identifying who to contact about funding this goal. Defaults to the [Rust Funding team](https://rust-lang.org/governance/teams/launching-pad/#team-funding) if omitted. Only relevant for goals with a `## Funding` section. |
 | **\[team\] champion** | No | The champion for a specific team, e.g. `[lang] champion \| @someone`. Medium and Large team asks require a champion. |
 | **Teams** | *Auto-injected* | Filled in automatically from team asks. Do not add this row yourself. |
 | **Task owners** | *Auto-injected* | Filled in automatically from work item tables. Do not add this row yourself. |
@@ -165,17 +166,19 @@ The `## Funding` section is optional. Include it if your goal needs financial su
 ```markdown
 ## Funding
 
-| Purpose | Cost | Status |
-|---------|------|--------|
-| Contributor (6 months, full-time) | $60,000 | 🔍 Looking |
-| Maintenance | $10,000 | 💬 Under discussion |
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| Contributor (6 months, full-time) | $60,000 | No | |
+| Maintenance | $10,000 | Partial | Acme Corp |
 ```
 
-The presence of this section signals that the goal is looking for funding. Goals that do not need funding should omit this section entirely. The table rows describe what the funding would cover (purpose), the estimated cost, and the current status. Status values are:
+The presence of this section signals that the goal is looking for funding. Goals that do not need funding should omit this section entirely. The table rows describe what the funding would cover (purpose), the estimated cost, the current funding status, and any sponsors. Funded values are:
 
-- 🔍 Looking — actively seeking a funder
-- 💬 Under discussion — in conversation with a potential funder
-- ✅ Finalized — funding secured
+- `No` — not yet funded
+- `Partial` — partially funded or in discussion
+- `Yes` — fully funded
+
+To specify who potential funders should contact, add a `Funding point of contact` row to the metadata table at the top of the file. This can be freeform text with markdown links, e.g. `[Trifecta Tech Foundation](https://trifectatech.org/)`. If omitted, it defaults to the [Rust Funding team](https://rust-lang.org/governance/teams/launching-pad/#team-funding).
 
 ### Frequently asked questions
 

--- a/src/about/goal-format.md
+++ b/src/about/goal-format.md
@@ -176,7 +176,7 @@ The presence of this section signals that the goal is looking for funding. Goals
 
 - `No` — not yet funded
 - `Partial` — partially funded or in discussion
-- `Yes` — fully funded
+- `Full` — fully funded
 
 To specify who potential funders should contact, add a `Funding point of contact` row to the metadata table at the top of the file. This can be freeform text with markdown links, e.g. `[Trifecta Tech Foundation](https://trifectatech.org/)`. If omitted, it defaults to the [Rust Funding team](https://rust-lang.org/governance/teams/launching-pad/#team-funding).
 


### PR DESCRIPTION
We now

- Collect information about which goals are funded and who is the sponsor
- Use colorful emojis for funding status: 🟥 (seeking), 🟡 (partial), ✅ (funded)
- Thank sponsors (currently just listed as Anon1, Anon2 until we have a bit more discussion)
- Replace "What and why" column with "Sponsor(s)" column showing 🙏 and sponsor names from the new Sponsor(s) field in per-goal funding tables
- Rename "Sponsor" header to "Funding POC" for clarity
- Add (((FUNDING LEGEND))) directive that renders a legend table from the same emoji constants used in the data rows
- Update all goal files, template, and docs to the new format
- Cleanup the table output

Example:

<img width="1686" height="2244" alt="image" src="https://github.com/user-attachments/assets/eb1064c5-5206-4e7e-9757-b90c64946d67" />

cc @tomassedovic 

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/about/goal-format.md)