### PR TITLE
fix: change reference labels starting with `#`

### DIFF
--- a/src/2026/interactive-cargo-tree.md
+++ b/src/2026/interactive-cargo-tree.md
@@ -1,12 +1,12 @@
 # Interactive cargo-tree: TUI for Cargo's dependency graph visualization
 
-| Metadata             |                                    |
-| :--                  | :--                                |
-| Point of contact     | @orhun                             |
-| Status               | Accepted                           |
-| Tracking issue       | [rust-lang/rust-project-goals#642] |
-| Other tracking issues | [#11213], [#15473]                 |
-| Zulip channel        | [TUI for Cargo]                    |
+| Metadata              |                                                  |
+| :--                   | :--                                              |
+| Point of contact      | @orhun                                           |
+| Status                | Accepted                                         |
+| Tracking issue        | [rust-lang/rust-project-goals#642]               |
+| Other tracking issues | [rust-lang/cargo#11213], [rust-lang/cargo#15473] |
+| Zulip channel         | [TUI for Cargo]                                  |
 
 
 ## Summary
@@ -73,8 +73,8 @@ In the distant future, implementing this would open up possibilities for adding 
 
 n/A
 
-[#11213]: https://github.com/rust-lang/cargo/issues/11213
-[#15473]: https://github.com/rust-lang/cargo/issues/15473
+[rust-lang/cargo#11213]: https://github.com/rust-lang/cargo/issues/11213
+[rust-lang/cargo#15473]: https://github.com/rust-lang/cargo/issues/15473
 [TUI for Cargo]: https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/TUI.20for.20cargo
 [`cargo-tree`]: https://doc.rust-lang.org/cargo/commands/cargo-tree.html
 [cargo-tree-tui]: https://github.com/orhun/cargo-tree-tui

--- a/src/2026/polonius.md
+++ b/src/2026/polonius.md
@@ -15,11 +15,11 @@
 
 ## Summary
 
-Stabilize the [polonius alpha][alpha] borrow checking analysis, which resolves [common limitations of the borrow checker][pc3] such as the [NLL problem case #3][pc3] and lending iterator patterns ([issue #92985]). This goal covers fixing the remaining known soundness issue, expanding test coverage, building a formal model in [a-mir-formality][] and upstreaming it into the Rust reference, validating performance, and preparing a stabilization report.
+Stabilize the [polonius alpha][alpha] borrow checking analysis, which resolves [common limitations of the borrow checker][pc3] such as the [NLL problem case #3][pc3] and lending iterator patterns ([rust-lang/rust#92985]). This goal covers fixing the remaining known soundness issue, expanding test coverage, building a formal model in [a-mir-formality][] and upstreaming it into the Rust reference, validating performance, and preparing a stabilization report.
 
 [alpha]: https://github.com/rust-lang/rust/pull/143093
 [pc3]: https://blog.rust-lang.org/inside-rust/2023/10/06/polonius-update.html#background-on-polonius
-[issue #92985]: https://github.com/rust-lang/rust/issues/92985
+[rust-lang/rust#92985]: https://github.com/rust-lang/rust/issues/92985
 [a-mir-formality]: https://github.com/rust-lang/a-mir-formality/
 
 ## Motivation

--- a/src/2026/polonius.md
+++ b/src/2026/polonius.md
@@ -15,11 +15,11 @@
 
 ## Summary
 
-Stabilize the [polonius alpha][alpha] borrow checking analysis, which resolves [common limitations of the borrow checker][pc3] such as the [NLL problem case #3][pc3] and lending iterator patterns ([#92985]). This goal covers fixing the remaining known soundness issue, expanding test coverage, building a formal model in [a-mir-formality][] and upstreaming it into the Rust reference, validating performance, and preparing a stabilization report.
+Stabilize the [polonius alpha][alpha] borrow checking analysis, which resolves [common limitations of the borrow checker][pc3] such as the [NLL problem case #3][pc3] and lending iterator patterns ([issue #92985]). This goal covers fixing the remaining known soundness issue, expanding test coverage, building a formal model in [a-mir-formality][] and upstreaming it into the Rust reference, validating performance, and preparing a stabilization report.
 
 [alpha]: https://github.com/rust-lang/rust/pull/143093
 [pc3]: https://blog.rust-lang.org/inside-rust/2023/10/06/polonius-update.html#background-on-polonius
-[#92985]: https://github.com/rust-lang/rust/issues/92985
+[issue #92985]: https://github.com/rust-lang/rust/issues/92985
 [a-mir-formality]: https://github.com/rust-lang/a-mir-formality/
 
 ## Motivation


### PR DESCRIPTION
mdbook does not like reference labels starting with `#`. It breaks the links and shows the reference labels as text in the site. I put them in line with other similar use-cases to make them work and make the links more unified. 

See:
https://rust-lang.github.io/rust-project-goals/2026/polonius.html#summary
https://rust-lang.github.io/rust-project-goals/2026/interactive-cargo-tree.html#frequently-asked-questions

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/interactive-cargo-tree.md)