### PR TITLE
Timeline tail calls

### DIFF
--- a/src/2026/tail-call-loop-match.md
+++ b/src/2026/tail-call-loop-match.md
@@ -48,7 +48,7 @@ In light of these design issues, we'd also like to continue development of `loop
 
 | Purpose | Cost | Funded | Sponsor(s) |
 |---------|------|--------|------------|
-| Contributor | $25,000 | No | |
+| Contributor | $25,000 | Full | [Tempo Labs](https://tempo.xyz/) |
 
 ## Target timeline
 

--- a/src/2026/tail-call-loop-match.md
+++ b/src/2026/tail-call-loop-match.md
@@ -30,12 +30,12 @@ In light of these design issues, we'd also like to continue development of `loop
 
 | Task                                                                                                        | Owner(s)             | Notes                                                                                                |
 | ----------------------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
-| add "computed goto" codegen to `loop_match`                                                                 | @folkertdev, @WaffleLapkin |                                                                                                      |
-| improve the `loop_match` implementation in `rustc_codegen_ssa`                                              | @folkertdev, @WaffleLapkin | - https://github.com/rust-lang/rust/issues/143806                                                    |
-| implement tail calls that pass arguments via the stack across targets (this may involve some work in LLVM)  | @folkertdev, @WaffleLapkin | - https://github.com/rust-lang/rust/pull/151143<br>- https://github.com/rust-lang/rust/issues/148748 |
-| validate tail calls on HIR instead of THIR                                                                  | @WaffleLapkin              |                                                                                                      |
-| accept tail call signatures that are a subtype                                                              | @WaffleLapkin              | - https://github.com/rust-lang/rust/issues/144953                                                    |
-| add experimental `extern "tail"` ABI that lowers to LLVM `tailcc` and lifts the same-signature restriction (this will probably require some work in LLVM)  | @WaffleLapkin, @folkertdev |                                                                                                      |
+| 1. add "computed goto" codegen to `loop_match`                                                                 | @folkertdev, @WaffleLapkin |                                                                                                      |
+| 2. improve the `loop_match` implementation in `rustc_codegen_ssa`                                              | @folkertdev, @WaffleLapkin | - https://github.com/rust-lang/rust/issues/143806                                                    |
+| 3. implement tail calls that pass arguments via the stack across targets (this may involve some work in LLVM)  | @folkertdev, @WaffleLapkin | - https://github.com/rust-lang/rust/pull/151143<br>- https://github.com/rust-lang/rust/issues/148748 |
+| 4. improve the validation checks for tail calls                                                             | @WaffleLapkin              |                                                                                                      |
+| 5. accept tail call signatures that are a subtype                                                              | @WaffleLapkin              | - https://github.com/rust-lang/rust/issues/144953                                                    |
+| 6. add experimental `extern "tail"` ABI that lowers to LLVM `tailcc` and lifts the same-signature restriction (this will probably require some work in LLVM)  | @WaffleLapkin, @folkertdev |                                                                                                      |
 
 ## Team asks
 
@@ -49,6 +49,16 @@ In light of these design issues, we'd also like to continue development of `loop
 | Purpose | Cost | Status |
 |---------|------|--------|
 | Contributor | $25,000 | 💬 Under discussion |
+
+## Target timeline
+
+The duration of the project is 6 months. Starting from the agreed start date ("Month 1"), the timeline we're targeting is:
+
+- Month 1-3: implementation work on items 1, 2, 3, 6 and publish blog post on "computed goto"
+- Month 4-5: implementation work on items 4, 5
+- Month 6: report completed items, report on any blocked items, and write summarizing blog post 
+
+The expected effort for the work is 2 person-months.
 
 ## Frequently asked questions
 


### PR DESCRIPTION
Adds target timeline section + sets funding status to "Full"  🥳

cc @folkertdev 

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/tail-call-loop-match.md)