### PR TITLE
fix: all the broken linkifier links.

### DIFF
--- a/src/2026/README.md
+++ b/src/2026/README.md
@@ -1,6 +1,6 @@
 - Feature Name: `project_goals_2026`
 - Start Date: 2026-02-23
-- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RFC PR: [RFC #3935]
 
 # Summary
 [summary]: #summary

--- a/src/2026/aarch64_pointer_authentication_pauthtest.md
+++ b/src/2026/aarch64_pointer_authentication_pauthtest.md
@@ -5,7 +5,7 @@
 | Point of contact     | @jchlanda                                       |
 | [compiler] champion  | @davidtwco                                      |
 | Status               | Accepted                                        |
-| Other tracking issue | https://github.com/rust-lang/rust/issues/148640 |
+| Other tracking issue | [rust-lang/rust#148640]                         |
 | Zulip channel        | N/A                                             |
 | Tracking issue       | [rust-lang/rust-project-goals#618]              |
 

--- a/src/2026/async-future-memory-optimisation.md
+++ b/src/2026/async-future-memory-optimisation.md
@@ -41,7 +41,7 @@ We would like to deliver the first `async`-future memory packing scheme `-Zpack-
 
 ### The status quo
 
-Exponential growth of `async`-future types has been a long-standing issue, tracked by #62958. In addition, any data that is alive and used across more than two `await` points will incur further penalty, because their memory slots are indiscriminately reserved throughout the futures' life span.
+Exponential growth of `async`-future types has been a long-standing issue, tracked by [rust-lang/rust#62958]. In addition, any data that is alive and used across more than two `await` points will incur further penalty, because their memory slots are indiscriminately reserved throughout the futures' life span.
 
 This issue has manifested in two ways that hinder the adoption of general `async` Rust or require use of unergonomic mitigations.
 
@@ -50,7 +50,7 @@ This issue has manifested in two ways that hinder the adoption of general `async
 
 ### What we propose to do about it
 
-A proposed fix has been proposed in #135527 which strives for perfect preservation of coroutine semantics while reducing the memory bloat contributed by coroutine captures, which has been the most common case for large future sizes. This experimental implementation work has shown success in improving future sizes. It also retains the default memory layout scheme in order to allow experimentation without affecting existing stable Rust users. Based on this foundation, the proposed work involves a second packing scheme to relax the overall layout computation, so that memory allocation can still be released even values are live across more than one `await` suspension points, enabling even further memory compaction. These changes will continue to abide by the design axiom, under which the surface Rust language remains unchanged and improvement work should be contained only in the internal Application Binary Interface (ABI) or code generation.
+A proposed fix has been proposed in [rust-lang/rust#135527] which strives for perfect preservation of coroutine semantics while reducing the memory bloat contributed by coroutine captures, which has been the most common case for large future sizes. This experimental implementation work has shown success in improving future sizes. It also retains the default memory layout scheme in order to allow experimentation without affecting existing stable Rust users. Based on this foundation, the proposed work involves a second packing scheme to relax the overall layout computation, so that memory allocation can still be released even values are live across more than one `await` suspension points, enabling even further memory compaction. These changes will continue to abide by the design axiom, under which the surface Rust language remains unchanged and improvement work should be contained only in the internal Application Binary Interface (ABI) or code generation.
 
 The proposed work also includes two further experiments as stretch goals.
 

--- a/src/2026/borrowsanitizer.md
+++ b/src/2026/borrowsanitizer.md
@@ -28,7 +28,7 @@ checks during compilation to detect errors at run-time. Its purpose is to find v
 aliasing model, as well as accesses out-of-bounds and use-after-free errors. 
 
 BorrowSanitizer relies on changes to the Rust compiler, an LLVM instrumentation pass, and a runtime library. We modified the compiler to emit special "retag" intrinsics that indicate when
-references are created and updated. Our LLVM pass lowers these intrinsics into runtime calls that associate each pointer with "provenance" metadata (see RFC [#3559](https://rust-lang.github.io/rfcs/3559-rust-has-provenance.html)). We validate provenance before memory accesses to detect undefined behavior. 
+references are created and updated. Our LLVM pass lowers these intrinsics into runtime calls that associate each pointer with "provenance" metadata (see [provenance RFC #3559](https://rust-lang.github.io/rfcs/3559-rust-has-provenance.html)). We validate provenance before memory accesses to detect undefined behavior. 
 
 Our primary goal is for BorrowSanitizer to be useful in practice. This will require broad support for Rust, C, and C++ language features. We want to achieve better performance than Miri while fully supporting the different features of Tree Borrows. 
 

--- a/src/2026/build-std.md
+++ b/src/2026/build-std.md
@@ -89,6 +89,3 @@ There are two primary objectives of this goal in this next goal cycle:
 ## Frequently asked questions
 
 None yet.
-
-[rust-lang/rfcs#3874]: https://github.com/rust-lang/rfcs/pull/3874
-[rust-lang/rfcs#3875]: https://github.com/rust-lang/rfcs/pull/3875

--- a/src/2026/cargo-cross-workspace-cache.md
+++ b/src/2026/cargo-cross-workspace-cache.md
@@ -31,10 +31,10 @@ A shared cache would:
 * Provide a central location to cleanup unneeded build artifacts (potentially automatically by Cargo)
 * Could be extended in the future to be pre-populated from a remote cache for CI usecases.
 
-In 2026, we will design and implement this cache in Cargo, making it available on nightly for users to begin experimenting with. (tracked in [cargo#5931](https://github.com/rust-lang/cargo/issues/5931))
+In 2026, we will design and implement this cache in Cargo, making it available on nightly for users to begin experimenting with. (tracked in [rust-lang/cargo#5931])
 As part of implementing the cache we will stabilize the `build-dir` [layout rework](https://github.com/rust-lang/cargo/issues/15010) that was done in 2025.
 In the beginning, the cache would be fairly conservative in what is cached but would be expanded over time.
-At the end of the year, we should have an understanding of the benefits and tradeoffs of the design we pick as well as a rough path towards stablization.
+At the end of the year, we should have an understanding of the benefits and tradeoffs of the design we pick as well as a rough path towards stabilization.
 
 ### Work items over the next year
 

--- a/src/2026/cargo-lints.md
+++ b/src/2026/cargo-lints.md
@@ -24,17 +24,17 @@ To help users in a way that can still be silenced, Cargo warns if `workspace.res
 Users can silence this by setting `workspace.resoler`.
 However, we can't raise awareness of `workspace.resolver` being stale because there wouldn't be a way to silence it.
 
-When considering a linting system in [#12235](https://github.com/rust-lang/cargo/issues/12235),
+When considering a linting system in [rust-lang/cargo#12235]
 we collected a good number of issues that would benefit from having one.
 
 ### What we propose to do about it
 
-This comes in two parts ([#12235](https://github.com/rust-lang/cargo/issues/12235)):
+This comes in two parts ([rust-lang/cargo#12235]):
 - Polish the linting system to be up to the quality of rustc and clippy
 - Implement an initial batch of lints to serve as examples for future lints, vet our design, and provide a motivation for stabilization and use
 
 In particular, we feel that native support for detecting unused dependencies
-([#15813](https://github.com/rust-lang/cargo/issues/15813))
+([rust-lang/cargo#15813])
 would provide a strong motivation for use of the linting system because it will,
 over time, improve build times.
 
@@ -49,7 +49,7 @@ See [the Cargo docs](https://doc.rust-lang.org/nightly/cargo/reference/lints.htm
 | Document lint contribution process | *epage*  |       |
 | Misc polish | *epage*  |       |
 
-See [#12235](https://github.com/rust-lang/cargo/issues/12235) for more details
+See [rust-lang/cargo#12235] for more details
 
 ## Team asks
 

--- a/src/2026/cargo-plumbing.md
+++ b/src/2026/cargo-plumbing.md
@@ -11,7 +11,7 @@
 
 1. Refactor Cargo to allow hacks in
 [proposed cargo-plumbing commands](https://github.com/crate-ci/cargo-plumbing)
-to be removed ([cargo-plumbing#82](https://github.com/crate-ci/cargo-plumbing/issues/82)).
+to be removed ([crate-ci/cargo-plumbing#82]).
 2. Round out proposed commands ([issues](https://github.com/crate-ci/cargo-plumbing/issues?q=is%3Aissue%20state%3Aopen%20label%3AA-new-subcommand))
 3. Finalize the message formats ([cargo-plumbing#18](https://github.com/crate-ci/cargo-plumbing/discussions/18))
 

--- a/src/2026/dictionary-passing-style-experiment.md
+++ b/src/2026/dictionary-passing-style-experiment.md
@@ -21,7 +21,7 @@ A lot of other languages, such as Scala, Haskell, and rocq also have traits/type
 
 ### The status quo
 
-Lazily recompute the used trait implementation on-demand during MIR borrowck and codegen ends up causing or at least allowing a bunch of bugs, e.g. [#57893](https://github.com/rust-lang/rust/issues/57893), [#149800](https://github.com/rust-lang/rust/pull/149800) and [lcnr/random-rust-snippets#23](https://github.com/lcnr/random-rust-snippets/issues/23).
+Lazily recompute the used trait implementation on-demand during MIR borrowck and codegen ends up causing or at least allowing a bunch of bugs, e.g. [rust-lang/rust#57893], [rust-lang/rust#149800] and [lcnr/random-rust-snippets#23].
 
 More generally, reproving trait bounds can fail if we're in a different environment. Because of this we cannot assume that fields are well-formed just because their containing struct is if we are in a generic context. The MIR inling also sometimes fails as the body of the inlined function is not be well-formed in the environment of the calling function. In general, a lot of places in the compiler have to handle normalization failing even though everything should already be well-formed.
 
@@ -29,7 +29,7 @@ Using dictionary passing would avoid these issues while also potentially improve
 
 ### What we propose to do about it
 
-There are a bunch of challenges to doing so, e.g. [lcnr/random-rust-snippets#2](https://github.com/lcnr/random-rust-snippets/issues/2). Associated types will have to store the dictionary which will be used to normalize them and we don't eagerly know that dictionary for things in signatures right now, as computing the dictionary depends on trait solving, which depends on signatures. This will requires introducing additional staging to type inference.
+There are a bunch of challenges to doing so, e.g. [lcnr/random-rust-snippets#2]. Associated types will have to store the dictionary which will be used to normalize them and we don't eagerly know that dictionary for things in signatures right now, as computing the dictionary depends on trait solving, which depends on signatures. This will requires introducing additional staging to type inference.
 
 We intend to work towards an initial experimental implementation and document issues uncovered during this work. We would like to either get to a working unstable implementation or have a clear understanding of why doing so is not possible.
 

--- a/src/2026/ergonomic-rc.md
+++ b/src/2026/ergonomic-rc.md
@@ -21,7 +21,7 @@ Implement and prototype two foundational improvements for ergonomic ref-counting
 
 Working with ref-counted data in Rust is a well-documented pain point. The problem affects high-level GUI applications (Dioxus, Sycamore), async network services (tokio), language interop (PyO3), and even the Rust compiler itself. Projects have gone to great lengths to work around it, from arena-based designs to custom preprocessors.
 
-This goal represents the culmination of extensive design exploration. After RFC #3680 proposed `.use` syntax and received mixed feedback, we spent 2025H2 deeply exploring the design space through [a series of blog posts][blog-series] and community discussions. Those discussions led to reframing the goal, focusing first on solutions **"low-level enough for a kernel, usable enough for a GUI"**.
+This goal represents the culmination of extensive design exploration. After [RFC #3680] proposed `.use` syntax and received mixed feedback, we spent 2025H2 deeply exploring the design space through [a series of blog posts][blog-series] and community discussions. Those discussions led to reframing the goal, focusing first on solutions **"low-level enough for a kernel, usable enough for a GUI"**.
 
 [blog-series]: https://smallcultfollowing.com/babysteps/series/ergonomic-rc/
 
@@ -130,7 +130,7 @@ The goal has taken a long journey:
 
 **2024H2:** Jonathan Kelley from Dioxus wrote a [blog post about high-level Rust][dioxus-post] that sparked the ergonomic ref-counting effort as a project goal.
 
-**2025H1:** RFC #3680 proposed `.use` syntax and `use ||` closures. Santiago Pastorino implemented experimental support on nightly. Community feedback was positive about addressing the problem but raised concerns about whether adding more required syntax actually improves ergonomics.
+**2025H1:** [RFC #3680] proposed `.use` syntax and `use ||` closures. Santiago Pastorino implemented experimental support on nightly. Community feedback was positive about addressing the problem but raised concerns about whether adding more required syntax actually improves ergonomics.
 
 **2025H2:** Through design meetings, the RustConf Unconf, and extensive blogging, we explored the design space more deeply. Key realizations emerged:
 
@@ -177,8 +177,6 @@ We considered several names. `Handle` is a good noun but awkward as a verb ("han
 
 Some applications genuinely need to track where aliases are created—for performance debugging, memory leak investigation, or APIs like `Arc::make_mut`. Making everything automatic would serve high-level apps well but fail the "low-level enough for a kernel" test. Our approach keeps aliases visible while reducing boilerplate. Once this is done, we will evaluate whether to continue with further changes.
 
-### How does this relate to RFC #3680?
+### How does this relate to [RFC #3680]?
 
-RFC #3680 proposed `.use` syntax and a `Use` trait. That work remains available on nightly and informed our thinking. This goal represents a refined direction based on community feedback and deeper exploration. The `Share` trait is similar in spirit to `Use` but with clearer semantics; move expressions address similar problems to `use ||` closures but generalize more naturally.
-
-[rust-lang/rust-project-goals#107]: https://github.com/rust-lang/rust-project-goals/issues/107
+[RFC #3680] proposed `.use` syntax and a `Use` trait. That work remains available on nightly and informed our thinking. This goal represents a refined direction based on community feedback and deeper exploration. The `Share` trait is similar in spirit to `Use` but with clearer semantics; move expressions address similar problems to `use ||` closures but generalize more naturally.

--- a/src/2026/improve-std-unsafe.md
+++ b/src/2026/improve-std-unsafe.md
@@ -18,7 +18,7 @@ Review unsafe code documentation in the Rust standard library, identify inconsis
 
 The Rust standard library provides many unsafe APIs accompanied by safety documentation. 
 While most unsafe APIs include safety sections, the quality of these documents does not always match the rigor of the code itself. 
-Inconsistencies exist, such as missing safety sections (e.g., [#138309](https://github.com/rust-lang/rust/pull/138309), [#146925](https://github.com/rust-lang/rust/pull/146925)) and incomplete safety properties (e.g., [#134953](https://github.com/rust-lang/rust/pull/134953), [#134496](https://github.com/rust-lang/rust/pull/134496), [#135009](https://github.com/rust-lang/rust/pull/135009)). A systematic review is therefore necessary to uphold the quality of this flagship component of Rust.
+Inconsistencies exist, such as missing safety sections (e.g., [rust-lang/rust#138309], [rust-lang/rust#146925]) and incomplete safety properties (e.g., [rust-lang/rust#134953], [rust-lang/rust#134496], [rust-lang/rust#135009]). A systematic review is therefore necessary to uphold the quality of this flagship component of Rust.
 
 Additionally, the Rust standard library lacks systematic guidelines for safety reasoning and unsafe code documentation. 
 As the library continues to grow in size and complexity, maintaining unsafe code documentation quality becomes increasingly challenging without such guidelines.
@@ -30,14 +30,14 @@ Finnaly, such a guideline is also needed by the community. For example, there ha
 
 ### What we propose to do about it
 
-- **Review unsafe code documentation in the Rust standard library, identify and resolve inconsistencies (missing safety sections and missing safety properties), following the approach taken in [#138309](https://github.com/rust-lang/rust/pull/138309), [#146925](https://github.com/rust-lang/rust/pull/146925), [#134953](https://github.com/rust-lang/rust/pull/134953), [#134496](https://github.com/rust-lang/rust/pull/134496), and [#135009](https://github.com/rust-lang/rust/pull/135009).** This effort will require continued collaboration between the opsem team and the standard library team, as in previous reviews.
+- **Review unsafe code documentation in the Rust standard library, identify and resolve inconsistencies (missing safety sections and missing safety properties), following the approach taken in [rust-lang/rust#138309], [rust-lang/rust#146925], [rust-lang/rust#134953], [rust-lang/rust#134496], and [rust-lang/rust#135009].** This effort will require continued collaboration between the opsem team and the standard library team, as in previous reviews.
 
   The inconsistency checking will be primarily based on the following mechanisms and will not introduce hard semantic-related issues.
   - **i. Missing safety sections:**
   For example, an unsafe API without the safety section in its doc.
   
   - **ii. Cross-checking API naming and parameters:**
-  API names and parameters often encode specific safety properties. For instance, the following four APIs (`from_raw(raw: *mut T)`, `from_raw_in(raw: *mut T, alloc: A)`, `from_non_null(ptr: NonNull<T>)`, `from_non_null_in(raw: NonNull<T>, alloc: A)`) of `Box` illustrate a naming convention. The substring `_in` indicates that the pointer must refer to a block of memory allocated by the provided allocator `alloc`. By contrast, APIs without the `_in` suffix imply that the pointer must refer to a block of memory allocated by the global allocator. Such naming patterns also exist in other structs like `Weak` and `Arc`. It is not difficult to detect and confirm inconsistencies among them. See [#135009](https://github.com/rust-lang/rust/pull/135009) and [#135805](https://github.com/rust-lang/rust/pull/135805) for more details.
+  API names and parameters often encode specific safety properties. For instance, the following four APIs (`from_raw(raw: *mut T)`, `from_raw_in(raw: *mut T, alloc: A)`, `from_non_null(ptr: NonNull<T>)`, `from_non_null_in(raw: NonNull<T>, alloc: A)`) of `Box` illustrate a naming convention. The substring `_in` indicates that the pointer must refer to a block of memory allocated by the provided allocator `alloc`. By contrast, APIs without the `_in` suffix imply that the pointer must refer to a block of memory allocated by the global allocator. Such naming patterns also exist in other structs like `Weak` and `Arc`. It is not difficult to detect and confirm inconsistencies among them. See [rust-lang/rust#135009] and [rust-lang/rust#135805] for more details.
 
   - **iii. Inference based on unsafe callees:**
   If an unsafe callee has safety requirements that are not enforced or discharged by the caller, this may indicate that a safety requirement is missing from the caller’s documentation.
@@ -104,7 +104,7 @@ Finnaly, such a guideline is also needed by the community. For example, there ha
 ### The "shiny future"
 
 - The standard can also be adopted by downstream Rust crates, promoting more consistent and sound unsafe code practices across the ecosystem. A particularly important beneficiary would be Rust for Linux, which places significant emphasis on the correct handling of unsafe code.
-- It can serve as a basis for future attribute-based safety documentation and checking, as proposed in [RFC 3842](https://github.com/rust-lang/rfcs/pull/3842). 
+- It can serve as a basis for future attribute-based safety documentation and checking, as proposed in [RFC #3842]. 
 
 ## Team asks
 
@@ -117,11 +117,10 @@ Finnaly, such a guideline is also needed by the community. For example, there ha
 
 ### What is the difference from goal [486](https://github.com/rust-lang/rust-project-goals/pull/486).
 
-[#486](https://github.com/rust-lang/rust-project-goals/pull/486) will start with Eclipse iceoryx2.
+[rust-lang/rust-project-goals#486] will start with Eclipse iceoryx2.
 > We’ll apply the zerocopy model systematically, starting with [Eclipse iceoryx2](https://github.com/eclipse-iceoryx/iceoryx2), a zero-copy IPC framework with ~3,300 unsafe usages.
 
 This goal focuses on identifying particular `unsafe` usage patterns for Eclipse iceoryx2 and tracing those back to relevant portions of the Rust Reference and standard library documentation. The main work is then to follow the work model of the [zerocopy](https://crates.io/crates/zerocopy) crate by working with the relevant teams to have normative language created in the Reference and standard library documentation such that safety-critical Rust users can build safety-cases upon them.
 > Priority areas include cross-process synchronization, memory-mapped regions, cross-process atomics, and UnsafeCell in shared memory—patterns common in systems programming but underdocumented.
 
 This goal is focused on ensuring that particular `unsafe` usages from the language and standard library are documented in a normative fashion as to how they behave. It would not produce a general standard or set of guidelines on how to use `unsafe` to mitigate risk of introducing undefined behavior.
-

--- a/src/2026/interactive-cargo-tree.md
+++ b/src/2026/interactive-cargo-tree.md
@@ -43,10 +43,10 @@ The goal for the next 6 months is to design and implement an interactive termina
 | Task                                   | Owner(s) | Notes                                                |
 | -------------------------------------- | -------- | ---------------------------------------------------- |
 | Implement basic interactive tree       | @orhun   | already done in [cargo-tree-tui]                     |
-| Match [`cargo-tree`] semantics         | @orhun   | [cargo-tree-tui#4]                                   |
-| Improve the UX & styling               | @orhun   | [cargo-tree-tui#8]                                   |
+| Match [`cargo-tree`] semantics         | @orhun   | [orhun/cargo-tree-tui#4]                             |
+| Improve the UX & styling               | @orhun   | [orhun/cargo-tree-tui#8]                             |
 | Directly depend on cargo as dependency | @orhun   | There might be some upstream APIs need to be changed |
-| Optimize for performance               | @orhun   | [cargo-tree-tui#37]                                  |
+| Optimize for performance               | @orhun   | [orhun/cargo-tree-tui#37]                            |
 | Prepare for inclusion in Cargo         | @orhun   | Integration and documentation work                   |
 
 ### The "shiny future" we are working towards
@@ -73,11 +73,6 @@ In the distant future, implementing this would open up possibilities for adding 
 
 n/A
 
-[rust-lang/cargo#11213]: https://github.com/rust-lang/cargo/issues/11213
-[rust-lang/cargo#15473]: https://github.com/rust-lang/cargo/issues/15473
 [TUI for Cargo]: https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/TUI.20for.20cargo
 [`cargo-tree`]: https://doc.rust-lang.org/cargo/commands/cargo-tree.html
 [cargo-tree-tui]: https://github.com/orhun/cargo-tree-tui
-[cargo-tree-tui#4]: https://github.com/orhun/cargo-tree-tui/issues/4
-[cargo-tree-tui#8]: https://github.com/orhun/cargo-tree-tui/issues/8
-[cargo-tree-tui#37]: https://github.com/orhun/cargo-tree-tui/issues/37

--- a/src/2026/libc-1.0.md
+++ b/src/2026/libc-1.0.md
@@ -5,7 +5,7 @@
 | Point of contact      | @JohnTitor                                                           |
 | Status                | Accepted                                                             |
 | Tracking issue        | [rust-lang/rust-project-goals#657]                                   |
-| Other tracking issues | [rust-lang/libc#3248](https://github.com/rust-lang/libc/issues/3248) |
+| Other tracking issues | [rust-lang/libc#3248]                                                |
 | Zulip channel         | N/A                                                                  |
 
 

--- a/src/2026/libtest-json.md
+++ b/src/2026/libtest-json.md
@@ -25,10 +25,10 @@ this helped show [how much people have come to rely on programmatic output](http
 Cargo could also benefit from programmatic test output to improve user interactions, including
 - [Wanting to run test binaries in parallel](https://github.com/rust-lang/cargo/issues/5609), like `cargo nextest`
 - [Lack of summary across all binaries](https://github.com/rust-lang/cargo/issues/4324)
-- [Noisy test output](https://github.com/rust-lang/cargo/issues/2832) (see also [#5089](https://github.com/rust-lang/cargo/issues/5089))
-- [Confusing command-line interactions](https://github.com/rust-lang/cargo/issues/1983) (see also [#8903](https://github.com/rust-lang/cargo/issues/8903), [#10392](https://github.com/rust-lang/cargo/issues/10392))
+- [Noisy test output](https://github.com/rust-lang/cargo/issues/2832) (see also [rust-lang/cargo#5089])
+- [Confusing command-line interactions](https://github.com/rust-lang/cargo/issues/1983) (see also [rust-lang/cargo#8903], [rust-lang/cargo#10392])
 - [Poor messaging when a filter doesn't match](https://github.com/rust-lang/cargo/issues/6151)
-- [Smarter test execution order](https://github.com/rust-lang/cargo/issues/6266) (see also [#8685](https://github.com/rust-lang/cargo/issues/8685), [#10673](https://github.com/rust-lang/cargo/issues/10673))
+- [Smarter test execution order](https://github.com/rust-lang/cargo/issues/6266) (see also [rust-lang/cargo#8685], [rust-lang/cargo#10673])
 - [JUnit output is incorrect when running multiple test binaries](https://github.com/rust-lang/rust/issues/85563)
 - [Lack of failure when test binaries exit unexpectedly](https://github.com/rust-lang/rust/issues/87323)
 

--- a/src/2026/mirroring.md
+++ b/src/2026/mirroring.md
@@ -16,7 +16,7 @@
 
 ## Summary
 
-We aim to ship a Minimum Viable Product that provides cryptographically verified mirrors for Rustup and Cargo, specifically targeting high-traffic environments like GitHub Actions (GHA) runners on Azure. By utilizing [The Update Framework (TUF)][tuf], we will establish a secure, multi-key distribution model that reduces infrastructure costs while providing for utilizing TUF as a validating mechanism on the backend transfers for mirroring, while integrating the needed unstable features into Rustup and Cargo for implementation. Our goal is to implement a first trial pass of [RFC#3724](https://github.com/rust-lang/rfcs/pull/3724), with modifications, allowing for mirrors of Rust releases and crates to be configurable or automatically utilized by the Rustup toolchain.
+We aim to ship a Minimum Viable Product that provides cryptographically verified mirrors for Rustup and Cargo, specifically targeting high-traffic environments like GitHub Actions (GHA) runners on Azure. By utilizing [The Update Framework (TUF)][tuf], we will establish a secure, multi-key distribution model that reduces infrastructure costs while providing for utilizing TUF as a validating mechanism on the backend transfers for mirroring, while integrating the needed unstable features into Rustup and Cargo for implementation. Our goal is to implement a first trial pass of [RFC #3724], with modifications, allowing for mirrors of Rust releases and crates to be configurable or automatically utilized by the Rustup toolchain.
 
 [tuf]: https://theupdateframework.io/
 

--- a/src/2026/move-trait.md
+++ b/src/2026/move-trait.md
@@ -9,7 +9,7 @@
 | Roadmap               | [Just add async](./roadmap-just-add-async.md)                                                        |
 | Roadmap               | [Rust for Linux](./roadmap-rust-for-linux.md)                                                        |
 | Tracking issue        | [rust-lang/rust-project-goals#635]                                                                   |
-| Other tracking issues | https://github.com/rust-lang/rust/issues/149607                                                      |
+| Other tracking issues | [rust-lang/rust#149607]                                                                              |
 | Zulip channel         | [#t-lang/move-trait](https://rust-lang.zulipchat.com/#narrow/channel/549962-t-lang.2Fmove-trait)     |
 | [types] champion      | @lcnr                                                                                                |
 | [lang] champion       | @jackh726                                                                                            |

--- a/src/2026/next-solver.md
+++ b/src/2026/next-solver.md
@@ -29,6 +29,8 @@ The next-generation trait solver is intended to fully replace the existing type 
 
 There are multiple type system unsoundnesses blocked on the next-generation trait solver: [project board][unsoundnesses]. Desirable features such as coinductive trait semantics and perfect derive, where-bounds on binders, and better handling of higher-ranked bounds and types are also stalled due to shortcomings of the existing implementation.
 
+[unsoundnesses]: https://github.com/orgs/rust-lang/projects/44/views/1
+
 Since starting to work on this at the EOY 2022, we've:
 - stabilized its use in coherence checking in Rust 1.84
 - replaced the use of `chalk` in `rust-analyzer`

--- a/src/2026/open-namespaces.md
+++ b/src/2026/open-namespaces.md
@@ -9,13 +9,13 @@
 
 ## Summary
 
-Navigate the cross-team design work to get [RFC 3243](https://github.com/rust-lang/rfcs/pull/3243) implemented.
+Navigate the cross-team design work to get [RFC #3243] implemented.
 
 **Needs contributor:** This goal needs contributors to help complete the implementations in Cargo, rustc, and crates.io. The work spans multiple repositories and involves cross-team coordination. Estimated time commitment: TBD.
 
 ## Motivation
 
-[RFC 3243](https://github.com/rust-lang/rfcs/pull/3243) proposed opening up namespaces in Rust to extension,
+[RFC #3243] proposed opening up namespaces in Rust to extension,
 managed by the package name with crates-io putting access control on who can publish to a crate's API namespace.
 This covers multiple teams and needs a lot of coordination to balance the needs of each team as shown on the [rustc tracking issue](https://github.com/rust-lang/rust/issues/122349).
 

--- a/src/2026/polonius.md
+++ b/src/2026/polonius.md
@@ -19,7 +19,6 @@ Stabilize the [polonius alpha][alpha] borrow checking analysis, which resolves [
 
 [alpha]: https://github.com/rust-lang/rust/pull/143093
 [pc3]: https://blog.rust-lang.org/inside-rust/2023/10/06/polonius-update.html#background-on-polonius
-[rust-lang/rust#92985]: https://github.com/rust-lang/rust/issues/92985
 [a-mir-formality]: https://github.com/rust-lang/a-mir-formality/
 
 ## Motivation
@@ -57,7 +56,7 @@ fn get_or_insert_default<'r, K: Hash + Eq + Copy, V: Default>(
 }
 ```
 
-A similar variation is the filtering lending iterator pattern, where `next()` reborrows `self` in a loop — code that NLLs incorrectly rejects today. Beyond being an ergonomic hazard, this limitation is also an expressiveness gap: it blocks the ability to write [lending iterator patterns][#92985] entirely.
+A similar variation is the filtering lending iterator pattern, where `next()` reborrows `self` in a loop — code that NLLs incorrectly rejects today. Beyond being an ergonomic hazard, this limitation is also an expressiveness gap: it blocks the ability to write [lending iterator patterns](https://github.com/rust-lang/rust/issues/92985) entirely.
 
 #### What the alpha analysis does not accept
 
@@ -84,8 +83,8 @@ Fix remaining issues, validate on real-world code, and ship a stable improved bo
 
 | Task | Owner(s) | Notes |
 | ---- | -------- | ----- |
-| Fix soundness issue with opaque types and dead regions | @lqd, @tiif | @tiif's [trait-system-refactor-initiative#159](https://github.com/rust-lang/trait-system-refactor-initiative/issues/159) is a pre-requisite for a borrowck fix |
-| Expand test coverage | @lqd | We've started doing this during the previous goal period, e.g. from open fixed-by-polonius issues in [#145053](https://github.com/rust-lang/rust/pull/145053) |
+| Fix soundness issue with opaque types and dead regions | @lqd, @tiif | @tiif's [rust-lang/trait-system-refactor-initiative#159] is a pre-requisite for a borrowck fix |
+| Expand test coverage | @lqd | We've started doing this during the previous goal period, e.g. from open fixed-by-polonius issues in [rust-lang/rust#145053] |
 | Enable polonius testing on CI | @lqd | |
 | Ship nightly preview behind feature gate | @lqd | With blog post / call for testing |
 | Validate performance on real-world code | @lqd, @amandasystems | |

--- a/src/2026/pub-priv.md
+++ b/src/2026/pub-priv.md
@@ -25,13 +25,10 @@ This will allow users to tell Rustc and Cargo what dependencies are private
 
 ### The status quo
 
-[RFC #1977](https://github.com/rust-lang/rfcs/pull/1977) has been superseded by
-[RFC #3516](https://github.com/rust-lang/rfcs/pull/3516) to reduce complexity on the Cargo side to help get this over the line.
+[RFC #1977] has been superseded by
+[RFC #3516] to reduce complexity on the Cargo side to help get this over the line.
 However, there is still a lot of complexity on the compiler side to get this right
-(
-[rust#3516](https://github.com/rust-lang/rfcs/pull/3516),
-[rust#119428](https://github.com/rust-lang/rust/issues/119428),
-),
+([RFC #3516], [rust-lang/rust#119428]),
 keeping this feature in limbo
 
 ### The next 6 months

--- a/src/2026/reborrow-traits.md
+++ b/src/2026/reborrow-traits.md
@@ -75,6 +75,5 @@ Originally `CoerceShared` had `type Target` to prevent multiple coercion targets
 
 Supporting multiple lifetimes requires dealing with rmeta (Rust metadata) complexity. Focusing on single-lifetime reborrowing first lets us get the core functionality working before tackling that additional complexity.
 
-[rust-lang/rust-project-goals#399]: https://github.com/rust-lang/rust-project-goals/issues/399
 [lang]: https://github.com/rust-lang/lang-team
 [compiler]: https://github.com/rust-lang/compiler-team

--- a/src/2026/reflection-and-comptime.md
+++ b/src/2026/reflection-and-comptime.md
@@ -41,7 +41,7 @@ If this experiment is successful, crates like `bevy` will be able to "just work"
 just to get the `bevy_reflect` information built at compile-time. Crates like `bevy_reflect` and `facet` will still exist, but only as different libraries with different goals and methods for exposing reflection information.
 
 Furthermore it opens up new possibilities of reflection-like behaviour by
-* specializing serialization on specific formats (e.g. serde won't support changing serialization depending on the serializer  https://github.com/serde-rs/serde/issues/2877),
+* specializing serialization on specific formats (e.g. serde won't support changing serialization depending on the serializer  [serde-rs/serde#2877]),
 * specializing trait impl method bodies to have more performant code paths for specific types, groups of types or shapes (e.g. based on the layout) of types.
 
 I consider reflection orthogonal to derives as they solve similar problems from different directions. Reflection lets you write the logic that processes your types in a way very similar to dynamic languages, by inspecting values' types during the execution of the reflection code, while derives generate the code that processes types ahead of time. Proc macros derives have historically been shown to be fairly hard to debug and bootstrap from scratch (we should totally also improve proc macro workflows). While reflection can get similarly complex fast, it allows for a more dynamic approach where you can easily debug the state your are in, as you do not have to pair the derive logic with the consumer logic (e.g. a serializer) and are instead directly writing just the consumer logic.

--- a/src/2026/rtn.md
+++ b/src/2026/rtn.md
@@ -100,7 +100,6 @@ where
 
 RTN has been fully implemented and is available on nightly under the feature flag `return_type_notation`.
 
-[RFC #3654]: https://rust-lang.github.io/rfcs/3654-return-type-notation.html
 
 #### RTN for async closures
 

--- a/src/2026/safe-unsafe-for-safety-critical.md
+++ b/src/2026/safe-unsafe-for-safety-critical.md
@@ -23,7 +23,7 @@ Rust's `unsafe` documentation has gaps. The Rustonomicon self-describes as "inco
 
 This matters acutely in safety-critical domains. Automotive, medical, and aerospace software must demonstrate code behaves correctly. Without normative documentation, developers cannot build rigorous safety cases for `unsafe` code.
 
-The [zerocopy crate](https://github.com/google/zerocopy) established a model: annotate every `unsafe` block with rationale citing official Rust documentation; when documentation is insufficient, work with t-opsem to improve it (e.g., [rust-lang/rust#114902](https://github.com/rust-lang/rust/issues/114902) for `addr_of!` semantics).
+The [zerocopy crate](https://github.com/google/zerocopy) established a model: annotate every `unsafe` block with rationale citing official Rust documentation; when documentation is insufficient, work with t-opsem to improve it (e.g., [rust-lang/rust#114902] for `addr_of!` semantics).
 
 ### What we'll do
 

--- a/src/2026/scalable-vectors.md
+++ b/src/2026/scalable-vectors.md
@@ -18,12 +18,12 @@ the `Sized` trait hierarchy and continue nightly support for scalable vectors:
 
 - Stabilize the refined `Sized` trait hierarchy (without constness), unblocking extern types
 - Propose and implement `const Sized` to support scalable vectors
-- Achieve RFC acceptance for [rfcs#3838] (Scalable Vectors)
+- Achieve RFC acceptance for [RFC #3838] (Scalable Vectors)
 - Land SVE types and intrinsics in stdarch for nightly experimentation
 - Continue addressing stabilization blockers for SVE itself
 - Begin design work for supporting the Scalable Matrix Extension (SME)
 
-The `const Sized` work (Part II of [rfcs#3729]) is deferred to a future goal,
+The `const Sized` work (Part II of [RFC #3729]) is deferred to a future goal,
 allowing us to deliver value sooner through the trait hierarchy stabilization.
 This future work interacts with ongoing [const generics][const-generics-goal]
 efforts, as `const Sized` depends on progress in const traits.
@@ -67,32 +67,22 @@ systems programming language with native support for these hardware capabilities
 
 Significant progress was made in 2025:
 
-- **Sized Hierarchy: Part I** ([rust#137944]) has been merged, introducing
+- **Sized Hierarchy: Part I** ([rust-lang/rust#137944]) has been merged, introducing
   new non-const sizing traits behind the `sized_hierarchy` feature gate
-- **Scalable vector infrastructure** ([rust#143924]) has been merged, adding
+- **Scalable vector infrastructure** ([rust-lang/rust#143924]) has been merged, adding
   experimental `rustc_scalable_vector(N)` attribute support
-- **Hierarchy of Sized traits** ([rfcs#3729]) is being implemented experimentally
+- **Hierarchy of Sized traits** ([RFC #3729]) is being implemented experimentally
 
-See the tracking issues for the Sized Hierarchy prerequisite ([rust#144404]) and
-for Scalable Vectors themselves ([rust#145052]).
-
-[rust#137944]: https://github.com/rust-lang/rust/pull/137944
-[rust#143924]: https://github.com/rust-lang/rust/pull/143924
-[rust#144404]: https://github.com/rust-lang/rust/issues/144404
-[rust#145052]: https://github.com/rust-lang/rust/issues/145052
-[rfcs#3729]: https://github.com/rust-lang/rfcs/pull/3729
-[rfcs#3838]: https://github.com/rust-lang/rfcs/pull/3838
-[stdarch#1509]: https://github.com/rust-lang/stdarch/pull/1509
+See the tracking issues for the Sized Hierarchy prerequisite ([rust-lang/rust#144404]) and
+for Scalable Vectors themselves ([rust-lang/rust#145052]).
 
 ### What we propose to do about it
 
-In 2026, we plan to factor out a subset of [RFC 3729] that can be stabilized
+In 2026, we plan to factor out a subset of [RFC #3729] that can be stabilized
 independently: traits like `SizeOfVal` that don't require const trait support.
-This subset unblocks extern types ([RFC 1861]), a long-requested feature, while
+This subset unblocks extern types ([RFC #1861]), a long-requested feature, while
 the const-specific portions needed for SVE itself remain experimental pending
 progress on const traits.
-
-[RFC 1861]: https://github.com/rust-lang/rfcs/pull/1861
 
 Our design axioms:
 
@@ -114,7 +104,7 @@ the next logical step, enabling efficient matrix processing in Rust.
 | Task                                          | Owner(s) or team(s) | Notes                                     |
 | --------------------------------------------- | ------------------- | ----------------------------------------- |
 | Stabilize Sized trait hierarchy               | @davidtwco          | Unblocks extern types                     |
-| Achieve RFC acceptance for [rfcs#3838]        | @davidtwco          | Scalable Vectors RFC                      |
+| Achieve RFC acceptance for [RFC #3838]        | @davidtwco          | Scalable Vectors RFC                      |
 | Update and reopen stdarch SVE PR              | @davidtwco          | SVE types and intrinsics                  |
 | Address SVE stabilization blockers            | @davidtwco          | Identify and resolve blockers             |
 | SME design exploration                        | @davidtwco          | Understand implications for Rust          |
@@ -124,7 +114,7 @@ the next logical step, enabling efficient matrix processing in Rust.
 | Team       | Support level | Notes                                                   |
 | ---------- | ------------- | ------------------------------------------------------- |
 | [compiler] | Medium         | Standard reviews for stabilization and SVE work         |
-| [lang]     | Medium        | RFC decision for [rfcs#3838], stabilization sign-off    |
+| [lang]     | Medium        | RFC decision for [RFC #3838], stabilization sign-off    |
 | [libs-api] | Medium        | Review RFC; review and approve stdarch SVE APIs         |
 | [types]    | Medium        | Type System implementation and stabilization sign-off   |
 
@@ -152,5 +142,3 @@ Extern types need a way to express "this type has no known size, not even at
 runtime." The current `?Sized` bound conflates "unsized but has metadata" with
 "truly sizeless." The refined trait hierarchy allows distinguishing
 these cases, which is the key blocker for extern types.
-
-[rust-lang/rust-project-goals#270]: https://github.com/rust-lang/rust-project-goals/issues/270

--- a/src/2026/specialization.md
+++ b/src/2026/specialization.md
@@ -6,7 +6,7 @@
 | Status                | Accepted                           |
 | Tracking issue        | [rust-lang/rust-project-goals#652] |
 | Zulip channel         | N/A                                |
-| Other tracking issues | rust-lang/rust#31844               |
+| Other tracking issues | [rust-lang/rust#31844]               |
 | [lang] champion       | @tmandry                           |
 | [types] champion      | @jackh726                          |
 
@@ -19,14 +19,13 @@ Work over this year will be done to identify key use cases of specialization and
 
 ### The status quo
 
-Specialization, the ability to branch (potentially through an impl) on type properties known at monomorphization time, is a long-sought feature in Rust. An initial [RFC][rfc] and [implementation][tracking] was made that broadly allows overlapping impls as long as one impl is an unambiguous "winner". However, there are soundness issues with this design.
+Specialization, the ability to branch (potentially through an impl) on type properties known at monomorphization time, is a long-sought feature in Rust. An initial [RFC #1210] and [implementation][tracking] was made that broadly allows overlapping impls as long as one impl is an unambiguous "winner". However, there are soundness issues with this design.
 
 A subset of specialization, coined the [“always applicable”][always applicable] subset, is restricted to implementations that hold regardless of lifetime substitution, roughly corresponding to specializing on concrete types. A feature gate, `min_specialization`, was split out that roughly approximates this subset. The feature was designed for use within the standard library, but was not intended as a stable user-facing feature. There are at the very least implementation bugs, but it is not clear if this subset of specialization is truly sound, or whether or not it can cover all the uses cases people need, both inside the standard library and in user crates.
 
 The next-generation trait solver, set to stabilize, resolves some bugs in the current implementation, though the work remaining is primarily one of design. Additionally, there have been alternative features proposed (`try_as_dyn` and `capability-safe specialization`) that function differently than “always applicable” specialization and cover different – largely overlapping – use cases.
 
 [always applicable]: https://smallcultfollowing.com/babysteps/blog/2018/02/09/maximally-minimal-specialization-always-applicable-impls/#when-is-an-impl-always-applicable
-[rfc]: https://github.com/rust-lang/rfcs/pull/1210
 [tracking]: https://github.com/rust-lang/rust/issues/31844
 
 ### What we propose to do about it

--- a/src/2026/stabilization-of-sanitizer-support.md
+++ b/src/2026/stabilization-of-sanitizer-support.md
@@ -24,7 +24,7 @@ In the meantime we work towards at least supporting [Tier 1](https://doc.rust-la
 
 ### The status quo
 
-Currently, there is unstable support for several sanitizers (address, hwaddress, memtag, memory, thread, leak, cfi, kcfi, safestack, shadow-call-stack). The AddressSanitizer and LeakSanitizer (that do not require rebuilding an instrumented standard library) are close to being stabilized (https://github.com/rust-lang/rust/pull/123617). We've just merged a new Tier 2 target (https://github.com/rust-lang/rust/pull/149644) for AddressSanitizer to allow using it with a stable compiler and are planning to repeat same process now for MemorySanitizer and ThreadSanitizer.
+Currently, there is unstable support for several sanitizers (address, hwaddress, memtag, memory, thread, leak, cfi, kcfi, safestack, shadow-call-stack). The AddressSanitizer and LeakSanitizer (that do not require rebuilding an instrumented standard library) are close to being stabilized ([rust-lang/rust#123617]). We've just merged a new Tier 2 target ([rust-lang/rust#149644]) for AddressSanitizer to allow using it with a stable compiler and are planning to repeat same process now for MemorySanitizer and ThreadSanitizer.
 
 ### What we propose to do about it
 

--- a/src/2026/stabilize-cargo-sbom.md
+++ b/src/2026/stabilize-cargo-sbom.md
@@ -5,7 +5,7 @@
 | Point of contact      | @Shnatsel                                       |
 | Status                | Accepted                                        |
 | Tracking issue        | [rust-lang/rust-project-goals#649]              |
-| Other tracking issues | https://github.com/rust-lang/cargo/issues/16565 |
+| Other tracking issues | [rust-lang/cargo#16565]                         |
 | Zulip channel         | N/A                                             |
 | [cargo] champion      | @weihanglo                                      |
 
@@ -32,7 +32,7 @@ Inaccurate SBOMs lead to false positives on vulnerability scans and/or complianc
 
 ### What we propose to do about it
 
-1. Complete [the RFC](https://github.com/rust-lang/rfcs/pull/3553) for this feature and get it accepted
+1. Complete [RFC #3553] for this feature and get it accepted
 1. Resolve the already known issue(s) in the Cargo SBOM precursor feature
 1. Modify [cargo-cyclonedx](https://crates.io/crates/cargo-cyclonedx) to use the Cargo SBOM precursor as a data source, to prove that it can be used to generate a complete and accurate SBOM in an industry standard format
 1. Address any issues that point 2 uncovers in the Cargo SBOM precursor feature

--- a/src/2026/stabilize-never-type.md
+++ b/src/2026/stabilize-never-type.md
@@ -5,7 +5,7 @@
 | Point of contact        | @WaffleLapkin                                  |
 | Status                  | Accepted                                       |
 | Tracking issue          | [rust-lang/rust-project-goals#653]             |
-| Other tracking issues | https://github.com/rust-lang/rust/issues/35121 |
+| Other tracking issues   | [rust-lang/rust#35121]                         |
 | Highlight               | Try, never, extern types                       |
 | Zulip channel           | N/A                                            |
 
@@ -31,10 +31,10 @@ After they are done, the never type can be stabilized.
 
 | Task                                                                 | Owner(s)                      | Notes                                           |
 | -------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------- |
-| Don't consider `Result<T, !>` as `must_use` unless `T` is            | @WaffleLapkin                 | https://github.com/rust-lang/rust/pull/148214   |
-| Improve dead-code lint to work with never type fallback              | @jdonszelmann, @WaffleLapkin  | https://github.com/rust-lang/rust/issues/146085 |
-| Further restrict what coercions are allowed on places of type `!` | @WaffleLapkin                 | https://github.com/rust-lang/rust/issues/131297 |
-| Re-assess the breakage needed for the fallback change               | @WaffleLapkin                 |                                                 |
+| Don't consider `Result<T, !>` as `must_use` unless `T` is            | @WaffleLapkin                 | [rust-lang/rust#148214]                      |
+| Improve dead-code lint to work with never type fallback              | @jdonszelmann, @WaffleLapkin  | [rust-lang/rust#146085]                         |
+| Further restrict what coercions are allowed on places of type `!`    | @WaffleLapkin                 | [rust-lang/rust#131297]                         |
+| Re-assess the breakage needed for the fallback change              v | @WaffleLapkin                 |                                                 |
 | Stabilize the never type!                                            | @WaffleLapkin                 |                                                 |
 
 ## Team asks

--- a/src/2026/stabilize-try.md
+++ b/src/2026/stabilize-try.md
@@ -4,7 +4,7 @@
 | :--                   | :--                                |
 | Point of contact      | @tmandry                           |
 | Status                | Accepted                           |
-| Other tracking issues | rust-lang/rust#84277               |
+| Other tracking issues | [rust-lang/rust#84277]             |
 | Zulip channel         | [#t-lang/try][channel]             |
 | Highlight             | Try, never, extern types           |
 | [lang] champion       | @tmandry                           |

--- a/src/2026/stabilizing-f16.md
+++ b/src/2026/stabilizing-f16.md
@@ -1,12 +1,12 @@
 # Stabilizing `f16`
 
-| Metadata              |                                                 |
-| :--                   | :--                                             |
-| Point of contact      | @folkertdev                                     |
-| Status                | Accepted                                        |
-| Tracking issue        | [rust-lang/rust-project-goals#655]              |
-| Other tracking issues | https://github.com/rust-lang/rust/issues/116909 |
-| Zulip channel         | N/A                                             |
+| Metadata              |                                                       |
+| :--                   | :--                                                   |
+| Point of contact      | @folkertdev                                           |
+| Status                | Accepted                                              |
+| Tracking issue        | [rust-lang/rust-project-goals#655]                    |
+| Other tracking issues | [rust-lang/rust#116909]                               |
+| Zulip channel         | N/A                                                   |
 | Funding contact       | [Trifecta Tech Foundation](https://trifectatech.org/) |
 
 ## Summary

--- a/src/2026/supertrait-auto-impl.md
+++ b/src/2026/supertrait-auto-impl.md
@@ -9,14 +9,14 @@
 | Roadmap               | Rust for Linux                                                                                           |
 | [lang] champion       | @cramertj                                                                                                |
 | Tracking issue        | [rust-lang/rust-project-goals#636]                                                                       |
-| Other tracking issues | rust-lang/rust#149556                                                                                    |
+| Other tracking issues | [rust-lang/rust#149556]                                                                                  |
 | Zulip channel         | N/A                                                                                                      |
 
 
 ## Summary
 
 Within the 2026 goal period we strive for completion of the following items.
-- Implementation of the core language features stipulated by the RFC 3851. See rust-lang/rfcs#3851.
+- Implementation of the core language features stipulated by the [RFC #3851].
 - Continuous update on the RFC for errata to reflect necessary changes as implementation moves along.
 - Resolve the `impl` overlapping question, possibly as an optional feature behind an associated feature gate.
 - Field trial of the standard library trait refactoring with the `supertrait_auto_impl` feature gate.

--- a/src/2026/tail-call-loop-match.md
+++ b/src/2026/tail-call-loop-match.md
@@ -5,7 +5,7 @@
 | Point of contact      | @folkertdev                                                                                      |
 | Status                | Accepted                                                                                         |
 | Tracking issue        | [rust-lang/rust-project-goals#634]                                                               |
-| Other tracking issues | https://github.com/rust-lang/rust/issues/112788, https://github.com/rust-lang/rust/issues/132306 |
+| Other tracking issues | [rust-lang/rust#112788], [rust-lang/rust#132306]                                                 |
 | Zulip channel         |                                                                                                  |
 | [lang] champion       | @scottmcm                                                                                        |
 | Funding contact       | [Trifecta Tech Foundation](https://trifectatech.org/) |
@@ -31,10 +31,10 @@ In light of these design issues, we'd also like to continue development of `loop
 | Task                                                                                                        | Owner(s)             | Notes                                                                                                |
 | ----------------------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
 | 1. add "computed goto" codegen to `loop_match`                                                                 | @folkertdev, @WaffleLapkin |                                                                                                      |
-| 2. improve the `loop_match` implementation in `rustc_codegen_ssa`                                              | @folkertdev, @WaffleLapkin | - https://github.com/rust-lang/rust/issues/143806                                                    |
-| 3. implement tail calls that pass arguments via the stack across targets (this may involve some work in LLVM)  | @folkertdev, @WaffleLapkin | - https://github.com/rust-lang/rust/pull/151143<br>- https://github.com/rust-lang/rust/issues/148748 |
+| 2. improve the `loop_match` implementation in `rustc_codegen_ssa`                                              | @folkertdev, @WaffleLapkin | [rust-lang/rust#143806]                                                    |
+| 3. implement tail calls that pass arguments via the stack across targets (this may involve some work in LLVM)  | @folkertdev, @WaffleLapkin | [rust-lang/rust#151143], [rust-lang/rust#148748] |
 | 4. improve the validation checks for tail calls                                                             | @WaffleLapkin              |                                                                                                      |
-| 5. accept tail call signatures that are a subtype                                                              | @WaffleLapkin              | - https://github.com/rust-lang/rust/issues/144953                                                    |
+| 5. accept tail call signatures that are a subtype                                                              | @WaffleLapkin              | [rust-lang/rust#144953]                                                    |
 | 6. add experimental `extern "tail"` ABI that lowers to LLVM `tailcc` and lifts the same-signature restriction (this will probably require some work in LLVM)  | @WaffleLapkin, @folkertdev |                                                                                                      |
 
 ## Team asks


### PR DESCRIPTION
This is a follow-up to #681. I found more broken links and decided to investigate and fix them all, after the link in the polonius project goal was still broken after that PR.

The root cause was actually the regex pattern in [book.toml](https://github.com/rust-lang/rust-project-goals/blob/main/book.toml#L20). Many links in the project goals were not displayed correctly, as the pre-processing broke the markdown syntax used by the contributors. This should fix all the problems for the 2026 goals and bring most links in line with a common convention.

- book.toml: I took the liberty to add another helper linkifier, because I saw the pattern repeated a bunch and many broken links because of it.
- [src/2026/README.md](https://rust-lang.github.io/rust-project-goals/2026/index.html) Fix link to 2026 goals RFC
- [src/2026/aarch64_pointer_authentication_pauthtest.md](https://rust-lang.github.io/rust-project-goals/2026/aarch64_pointer_authentication_pauthtest.html) Make the other tracking issues a link
- [src/2026/async-future-memory-optimisation.md](https://rust-lang.github.io/rust-project-goals/2026/async-future-memory-optimisation.html) make mentioned issues to links
- [src/2026/borrowsanitizer.md](https://rust-lang.github.io/rust-project-goals/2026/borrowsanitizer.html) fix provenance rfc link
- [src/2026/build-std.md](https://rust-lang.github.io/rust-project-goals/2026/build-std.html) Remove broken links at the bottom of the page
- [src/2026/cargo-cross-workspace-cache.md](https://rust-lang.github.io/rust-project-goals/2026/cargo-cross-workspace-cache.html) bring link to cargo issue in line and fix typo
- [src/2026/cargo-lints.md](https://rust-lang.github.io/rust-project-goals/2026/cargo-lints.html) Fix a bunch of broken links to cargo issues
- [src/2026/cargo-plumbing.md](https://rust-lang.github.io/rust-project-goals/2026/cargo-plumbing.html) bring a link in line
- [src/2026/dictionary-passing-style-experiment.md](https://rust-lang.github.io/rust-project-goals/2026/dictionary-passing-style-experiment.html) fix several broken links.
- [src/2026/ergonomic-rc.md](https://rust-lang.github.io/rust-project-goals/2026/ergonomic-rc.html) link rfcs
- [src/2026/improve-std-unsafe.md](https://rust-lang.github.io/rust-project-goals/2026/improve-std-unsafe.html) bring links in line
- [src/2026/interactive-cargo-tree.md](https://rust-lang.github.io/rust-project-goals/2026/interactive-cargo-tree.html) bring links in line
- [src/2026/libc-1.0.md](https://rust-lang.github.io/rust-project-goals/2026/libc-1.0.html) fix link
- [src/2026/libtest-json.md](https://rust-lang.github.io/rust-project-goals/2026/libtest-json.html) fix links and bring them in line
- [src/2026/mirroring.md](https://rust-lang.github.io/rust-project-goals/2026/mirroring.html) bring links in line
- [src/2026/move-trait.md](https://rust-lang.github.io/rust-project-goals/2026/move-trait.html) link other tracking issues
- [src/2026/next-solver.md](https://rust-lang.github.io/rust-project-goals/2026/next-solver.html) Add link to github dashboard
- [src/2026/open-namespaces.md](https://rust-lang.github.io/rust-project-goals/2026/open-namespaces.html) bring links in line
- [src/2026/polonius.md](https://rust-lang.github.io/rust-project-goals/2026/polonius.html) fix the same problem from #681 again.
- [src/2026/pub-priv.md](https://rust-lang.github.io/rust-project-goals/2026/pub-priv.html) fix broken links
- [src/2026/reborrow-traits.md](https://rust-lang.github.io/rust-project-goals/2026/reborrow-traits.html) remove redunant (and broken) links
- [src/2026/reflection-and-comptime.md](https://rust-lang.github.io/rust-project-goals/2026/reflection-and-comptime.html) link to serde (if anyone reading the rust project goals hasn't heard of it)
- [src/2026/rtn.md](https://rust-lang.github.io/rust-project-goals/2026/rtn.html) remove broken links
- [src/2026/safe-unsafe-for-safety-critical.md](https://rust-lang.github.io/rust-project-goals/2026/safe-unsafe-for-safety-critical.html) fix broken link
- [src/2026/scalable-vectors.md](https://rust-lang.github.io/rust-project-goals/2026/scalable-vectors.html) bring links in line and remove broken link at the bottom of the page
- [src/2026/specialization.md](https://rust-lang.github.io/rust-project-goals/2026/specialization.html) link other tracking issues
- [src/2026/stabilization-of-sanitizer-support.md](https://rust-lang.github.io/rust-project-goals/2026/stabilization-of-sanitizer-support.html) bring links in line
- [src/2026/stabilize-cargo-sbom.md](https://rust-lang.github.io/rust-project-goals/2026/stabilize-cargo-sbom.html) fix rfc link and link other tracking issues
- [src/2026/stabilize-never-type.md](https://rust-lang.github.io/rust-project-goals/2026/stabilize-never-type.html) add more links.
- [src/2026/stabilize-try.md](https://rust-lang.github.io/rust-project-goals/2026/stabilize-try.html) link other tracking issues
- [src/2026/stabilizing-f16.md](https://rust-lang.github.io/rust-project-goals/2026/stabilizing-f16.html) align the markdown table
- [src/2026/supertrait-auto-impl.md](https://rust-lang.github.io/rust-project-goals/2026/supertrait-auto-impl.html)  link other tracking issues and rfc
- [src/2026/tail-call-loop-match.md](https://rust-lang.github.io/rust-project-goals/2026/tail-call-loop-match.html) link other tracking issues and other issues.



[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/scalable-vectors.md)