### PR TITLE
add goal for `x87_f80`, `ibm_f128` and `c_longdouble` (for C interop)

### DIFF
--- a/src/2026/interop-f80-f128.md
+++ b/src/2026/interop-f80-f128.md
@@ -1,0 +1,92 @@
+# C interop: `f80`, `f128` and `c_longdouble`
+
+| Metadata              |                                                       |
+| :--                   | :--                                                   |
+| Point of contact      | @folkertdev                                           |
+| Status                | Proposed                                              |
+| What and why          | |
+| Tracking issue        |                                                       |
+| Other tracking issues | N/A                                                   |
+| Zulip channel         | N/A                                                   |
+| Funding contact       | [Trifecta Tech Foundation](https://trifectatech.org/) |
+
+## Summary
+
+Rust should be able to define an ABI-compatible counterpart to every signature that C can define. This is important for C interop and translation of code from C to rust, using manual FFI, and tooling like `c-bindgen` and `c2rust`. This goal closes a long-standing gap in rust's ability to match C.
+
+## Motivation
+
+### The status quo
+
+Today there are still a number of cases where rust cannot, in a portable way, express type signatures that C can define.
+
+The C `long double` type is one such missing piece. Normally rust provides the C-compatible types as type aliases (e.g. `type c_int = i32`), but `c_longdouble` requires additional types: on many platforms it maps to `f64`, but on some it maps instead to an 80-bit or 128-bit float, two types that are not currently available in stable rust.
+
+We will add the types (with no or very limited arithmetic operations) for interop purposes.
+
+### What we propose to do about it
+
+We will add two new storage-only float types to `core::arch` to facilitate with interop:
+
+- `core::arch::x86::x87_f80`, only available on `x86` and `x86_64`
+- `core::arch::powerpc::ibm_f128`, only available on `powerpc`, `powerpc64` and `powerpc64le`
+
+The API will be minimal, and will not include any arithmetic operations. Those operations can be added later.
+
+We will also continue to push `f128` forward, both on the LLVM and rustc side.
+
+### Work items over the next year
+
+> *Sketch out the specific things you are trying to achieve in this goal period. This should be short and high-level -- we don't want to see the design!*
+
+| Task        | Owner(s) | Notes |
+| ----------- | -------- | ----- |
+| implement `core::arch::x86::x87_f80` | @folkertdev  |       |
+| implement `core::arch::powerpc::ibm_f128` | @folkertdev  |       |
+| `f128` `ToString`/`FromString` | @folkertdev` | There is some active work on these algorithms, we'll try to help out where we can |
+| `core::arch::powerpc::ibm_f128` `ToString`/`FromString`  | @folkertdev  |       |
+| add `f128` assembly support for riscv in LLVM & rustc | @folkertdev | |
+| fix the `f128` windows ABI in LLVM | @folkertdev, @tgross35 | we will likely need support from the LLVM/Microsoft side here |
+| stabilize `core::arch::x86::x87_f80` | @folkertdev  |       |
+| stabilize `core::arch::powerpc::ibm_f128` | @folkertdev  |       |
+| attempt to stabilize `core::ffi::c_longdouble` | @folkertdev  | if the types must have (some) arithmetic operations, we might need more time |
+
+## Team asks
+
+| Team       | Support level | Notes                                   |
+| ---------- | ------------- | --------------------------------------- |
+| [compiler] | Medium        | The changes are not complicated, but touch some core types so this might need some design/refactoring to get right |
+| [lang]     | Small         | These new types have a new ABI          |
+| [libs-api] | Small         | Just a vibe check on the names and minimal APIs |
+
+## Funding
+
+| Purpose | Cost | Funded | Sponsor(s) |
+|---------|------|--------|------------|
+| implementation work | $36,000 | No | |
+
+## Target timeline
+
+The duration of the project is 12 months. Starting from the agreed start date ("Month 1"), the timeline we're targeting is:
+
+- Month 1-3: unstable `c_longdouble`, `x87_f80` and `ibm_f128` on nightly
+- Month 3-9: improvements to `f128` in rustc and LLVM
+- Month 9-12: stabilize `x87_f80` and `ibm_f128`, prepare stabilization of `c_longdouble`
+
+The expected effort for the work is 3 person-months, the long timeline is really due to LLVM release cycles.
+
+## Notes
+
+There is a stalled RFC for some of these types at https://github.com/rust-lang/rfcs/pull/3456.
+
+Blockers for `f128` support are tracked at [`cfg.has_reliable_f128`](https://github.com/rust-lang/rust/blob/2cfb951a24de2520de67f6911fd1fc0045a2662e/compiler/rustc_codegen_llvm/src/llvm_util.rs#L394-L415).
+
+There is a draft PR https://github.com/rust-lang/rust/pull/140417 for `c_longdouble` that already lists the right type for `c_longdouble` for many targets.
+
+Further discussion is at [#t-libs > &#96;f80&#96;, &#96;f128&#96; and &#96;c_longdouble&#96;](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/.60f80.60.2C.20.60f128.60.20and.20.60c_longdouble.60/with/604820894).
+
+## Frequently asked questions
+
+### What do I do with this space?
+
+*This is a good place to elaborate on your reasoning above -- for example, why did you put the design axioms in the order that you did? It's also a good place to put the answers to any questions that come up during discussion. The expectation is that this FAQ section will grow as the goal is discussed and eventually should contain a complete summary of the points raised along the way.*

--- a/src/2026/interop-f80-f128.md
+++ b/src/2026/interop-f80-f128.md
@@ -37,8 +37,6 @@ We will also continue to push `f128` forward, both on the LLVM and rustc side.
 
 ### Work items over the next year
 
-> *Sketch out the specific things you are trying to achieve in this goal period. This should be short and high-level -- we don't want to see the design!*
-
 | Task        | Owner(s) | Notes |
 | ----------- | -------- | ----- |
 | implement `core::arch::x86::x87_f80` | @folkertdev  |       |
@@ -87,6 +85,4 @@ Further discussion is at [#t-libs > &#96;f80&#96;, &#96;f128&#96; and &#96;c_lon
 
 ## Frequently asked questions
 
-### What do I do with this space?
-
-*This is a good place to elaborate on your reasoning above -- for example, why did you put the design axioms in the order that you did? It's also a good place to put the answers to any questions that come up during discussion. The expectation is that this FAQ section will grow as the goal is discussed and eventually should contain a complete summary of the points raised along the way.*
+(None.)

--- a/src/2026/stabilizing-f16.md
+++ b/src/2026/stabilizing-f16.md
@@ -8,6 +8,7 @@
 | Other tracking issues | [rust-lang/rust#116909]                               |
 | Zulip channel         | N/A                                                   |
 | Funding contact       | [Trifecta Tech Foundation](https://trifectatech.org/) |
+| [compiler] champion   | @tgross35                                             |
 
 ## Summary
 


### PR DESCRIPTION
This goal has been extracted from the `f16` project goal. Here we have more focus on interop/FFI.

I believe that the idea was that new project goals could be added at any time. I'm not sure how much of that has already been implemented. Anyhow, we're submitting this now.

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/interop-f80-f128.md)