### PR TITLE
Add help wanted for reborrow

### DIFF
--- a/src/2026/reborrow-traits.md
+++ b/src/2026/reborrow-traits.md
@@ -61,6 +61,13 @@ The fundamental design philosophy remains:
 | [compiler] | Small         | Standard reviews for maintainability of changes |
 | [types]    | Medium        | MIR restructuring for borrowck |
 
+## Help wanted
+
+| Task | Experience level | Time investment |
+|------|-----------------|-----------------|
+| Help with borrow checking ([context](https://github.com/rust-lang/rust-project-goals/issues/399#issuecomment-4917408838)) | If you're an expert on the internals of borrowck and have a good idea of how to teach borrowck about `&mut T` reborrows happening at arbitrary depths during a Reborrow, then please come talk to me! |  |
+| Help with rmeta / caching ([context](https://github.com/rust-lang/rust-project-goals/issues/399#issuecomment-4917408838)) | If you're an expert on rmeta / caching, then I'd again love your help on how to avoid/cache the Reborrow recursion result. |  |
+
 ## Frequently asked questions
 
 ### How does this relate to Pin ergonomics?


### PR DESCRIPTION
If I had a tetri for every time I added a help wanted section for a `&`-related goal today, I'd have two tetrebi — which isn't a lot, but it's weird that it happened twice (#716).

cc @aapoalas 

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/reborrow-traits.md)