### PR TITLE
Add AWS as the funder for Incr. Systems Rethought

### DIFF
--- a/src/2026/incremental-system-rethought.md
+++ b/src/2026/incremental-system-rethought.md
@@ -87,7 +87,7 @@ The first step is completing the RFC and implementing it in an unstable stage.
 
 | Purpose | Cost | Funded | Sponsor(s) |
 |---------|------|--------|------------|
-| Contributor | $75,000-$120,000 | Partial | |
+| Contributor | $75,000-$120,000 | Partial | [AWS](https://aws.amazon.com/) |
 
 Greater amount of funding would allow for more time spent working on the goal. If the funding goal is not met, part-time work will be given instead.
 


### PR DESCRIPTION
Currently AWS is the organization funding that "Partial" state

cc @jlizen

[Rendered](https://github.com/rust-lang/rust-project-goals/blob/main/src/2026/incremental-system-rethought.md)