### PR TITLE
Fix confusing typo in 2026/move-trait

### DIFF
--- a/src/2026/move-trait.md
+++ b/src/2026/move-trait.md
@@ -52,7 +52,7 @@ Types implementing `!Move` cannot be moved and must keep a stable address for th
 
 ```rust
 // Types implementing !Forget must have their destructors run
-unsafe impl !Forget for ScopedTaskHandle {}
+impl !Forget for ScopedTaskHandle {}
 ```
 
 With `!Forget`, we could build safe scoped spawn: the handle's destructor joins the task, and because the handle can't be forgotten, the join is guaranteed. This unblocks patterns that are currently impossible in safe Rust.


### PR DESCRIPTION
Negative impls cannot be unsafe (that's E0198).

[Rendered](https://github.com/rust-lang/goals/blob/main/src/2026/move-trait.md)