### PR TITLE
Update funding status for f80/f128

### DIFF
--- a/src/2026/interop-f80-f128.md
+++ b/src/2026/interop-f80-f128.md
@@ -60,7 +60,7 @@ We will also continue to push `f128` forward, both on the LLVM and rustc side.
 
 | Purpose | Cost | Funded | Sponsor(s) |
 |---------|------|--------|------------|
-| implementation work | $36,000 | No | |
+| implementation work | $36,000 | Full | Google |
 
 ## Target timeline
 


### PR DESCRIPTION
We landed a sponsor for the "C interop: f80, f128 .." goal.

cc @folkertdev 

[Rendered](https://github.com/rust-lang/goals/blob/main/src/2026/interop-f80-f128.md)