### PR TITLE
Fix failing markdown CI lint

### DIFF
--- a/src/2026/rustc-public.md
+++ b/src/2026/rustc-public.md
@@ -2,7 +2,7 @@
 
 | Metadata         |                                   |
 | :--------------- | --------------------------------- |
-| Point of contact | @makai410                         |
+| Contact | @makai410                         |
 | Status           | Proposed                          |
 | [project-rustc-public] champion | @celinval          |
 | Tracking issue   | [rust-lang/goals#266]             |


### PR DESCRIPTION
Rename "Point of Contact" in rustc-public to "Contact".

[Rendered](https://github.com/rust-lang/goals/blob/main/src/2026/rustc-public.md)