### PR TITLE
Preserve manual labels, mark goal as accepted

### DIFF
--- a/crates/rust-project-goals-cli/src/rfc.rs
+++ b/crates/rust-project-goals-cli/src/rfc.rs
@@ -584,8 +584,22 @@ fn initialize_issues<'doc>(
                     .iter()
                     .map(|label| label.name.clone())
                     .collect();
-                let desired_label_names: BTreeSet<String> =
-                    desired_issue.labels.iter().cloned().collect();
+                let desired_label_names: BTreeSet<String> = desired_issue
+                    .labels
+                    .iter()
+                    .cloned()
+                    .chain(existing_issue.labels.iter().filter_map(|label| {
+                        matches!(
+                            label.name.as_str(),
+                            "ex-2025h2"
+                                | "Flagship Goal"
+                                | "R-every-4-weeks"
+                                | "R-every-2-weeks"
+                                | "R-every-week"
+                        )
+                        .then(|| label.name.clone())
+                    }))
+                    .collect();
 
                 if existing_label_names != desired_label_names {
                     actions.insert(GithubAction::SyncLabels {

--- a/src/2026/rustc-public.md
+++ b/src/2026/rustc-public.md
@@ -3,7 +3,7 @@
 | Metadata         |                                   |
 | :--------------- | --------------------------------- |
 | Contact | @makai410                         |
-| Status           | Proposed                          |
+| Status           | Accepted                          |
 | [project-rustc-public] champion | @celinval          |
 | Tracking issue   | [rust-lang/goals#266]             |
 | Timespan         | 2026-2027                         |


### PR DESCRIPTION
Fixes `cargo rpg issues` removing manually set labels

[Rendered](https://github.com/rust-lang/goals/blob/main/src/2026/rustc-public.md)